### PR TITLE
server_id, client: fix build

### DIFF
--- a/cmds/client/main.go
+++ b/cmds/client/main.go
@@ -42,7 +42,7 @@ func main() {
 	}
 	duid := dhcpv6.Duid{
 		Type:          dhcpv6.DUID_LLT,
-		HwType:        iana.HwTypeEthernet,
+		HwType:        iana.HWTypeEthernet,
 		Time:          dhcpv6.GetTime(),
 		LinkLayerAddr: mac,
 	}

--- a/plugins/server_id/plugin.go
+++ b/plugins/server_id/plugin.go
@@ -88,7 +88,7 @@ func setupServerID6(args ...string) (handler.Handler6, error) {
 		V6ServerID = &dhcpv6.Duid{
 			Type: dhcpv6.DUID_LL,
 			// sorry, only ethernet for now
-			HwType:        iana.HwTypeEthernet,
+			HwType:        iana.HWTypeEthernet,
 			LinkLayerAddr: hwaddr,
 		}
 	case "llt", "duid-llt", "duid_llt":
@@ -97,7 +97,7 @@ func setupServerID6(args ...string) (handler.Handler6, error) {
 			// sorry, zero-time for now
 			Time: 0,
 			// sorry, only ethernet for now
-			HwType:        iana.HwTypeEthernet,
+			HwType:        iana.HWTypeEthernet,
 			LinkLayerAddr: hwaddr,
 		}
 	case "en", "uuid":


### PR DESCRIPTION
Fix `server_id` plugin and client cmd after changes in the `iana` package of the dhcp library.