### PR TITLE
Config file now requires interface name

### DIFF
--- a/cmds/coredhcp/config.yml.example
+++ b/cmds/coredhcp/config.yml.example
@@ -1,12 +1,13 @@
 server6:
-    listen: '[::]:547'
+    listen: '[ff02::1:2]:547'
+    interface: "eth0"
     plugins:
         - server_id: LL 00:de:ad:be:ef:00
         - file: "leases.txt"
         # - dns: 8.8.8.8 8.8.4.4 2001:4860:4860::8888 2001:4860:4860::8844
 
-#server4:
-#    listen: '0.0.0.0:67'
-#    plugins:
-#        - server_id: 192.168.1.12
-##        - file: "leases.txt"
+server4:
+    listen: '0.0.0.0:67'
+    interface: "eth0"
+    plugins:
+        - server_id: 192.168.1.12


### PR DESCRIPTION
The interface name is necessary to create multicast listeners.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>