### PR TITLE
Fix crash when receiving relayed message and deciding to not answer it

### DIFF
--- a/coredhcp.go
+++ b/coredhcp.go
@@ -141,6 +141,10 @@ func (s *Server) MainHandler6(conn net.PacketConn, peer net.Addr, req dhcpv6.DHC
 			break
 		}
 	}
+	if resp == nil {
+		log.Print("MainHandler6: dropping request because response is nil")
+		return
+	}
 
 	// if the request was relayed, re-encapsulate the response
 	if req.IsRelay() {
@@ -152,12 +156,8 @@ func (s *Server) MainHandler6(conn net.PacketConn, peer net.Addr, req dhcpv6.DHC
 		resp = tmp
 	}
 
-	if resp != nil {
-		if _, err := conn.WriteTo(resp.ToBytes(), peer); err != nil {
-			log.Printf("MainHandler6: conn.Write to %v failed: %v", peer, err)
-		}
-	} else {
-		log.Print("MainHandler6: dropping request because response is nil")
+	if _, err := conn.WriteTo(resp.ToBytes(), peer); err != nil {
+		log.Printf("MainHandler6: conn.Write to %v failed: %v", peer, err)
 	}
 }
 


### PR DESCRIPTION
When receiving a relay-forwarded message and deciding to not answer it,
the server would crash with the following panic:

```
[2019-09-12T15:22:06+02:00]  INFO plugins/file: looking up an IP address for MAC 16:34:d5:e9:47:10
[2019-09-12T15:22:06+02:00]  WARN plugins/file: MAC address 16:34:d5:e9:47:10 is unknown
panic: interface conversion: dhcpv6.DHCPv6 is nil, not *dhcpv6.Message

goroutine 7 [running]:
github.com/coredhcp/coredhcp.(*Server).MainHandler6(0xc0000ce730, 0x9fbdc0, 0xc000010100, 0x9f35c0, 0xc00013b230, 0x9fd400, 0xc0000ce8c0)
	/[...]/coredhcp/coredhcp.go:147 +0x659
created by github.com/insomniacslk/dhcp/dhcpv6/server6.(*Server).Serve
	$GOPATH/.go/pkg/mod/github.com/insomniacslk/dhcp@v0.0.0-20190814082028-393ae75a101b/dhcpv6/server6/server.go:96 +0x329
```

Since we are trying to reencapsulate the response in relay-reply messages before checking for !nil, and in this case the reply to reencapsulate is nil, the typecast panics