### PR TITLE
plugins/server_id: Reject DHCPv6 requests with invalid ServerID options

### DIFF
--- a/plugins/file/plugin.go
+++ b/plugins/file/plugin.go
@@ -149,7 +149,13 @@ func Handler6(req, resp dhcpv6.DHCPv6) (dhcpv6.DHCPv6, bool) {
 			net.ParseIP("2001:4860:4860::4444"),
 		},
 	})
-	if oro := req.GetOption(dhcpv6.OptionORO); len(oro) > 0 {
+
+	decap, err := req.GetInnerMessage()
+	if err != nil {
+		log.Errorf("Could not decapsulate: %v", err)
+		return nil, true
+	}
+	if oro := decap.GetOption(dhcpv6.OptionORO); len(oro) > 0 {
 		for _, code := range oro[0].(*dhcpv6.OptRequestedOption).RequestedOptions() {
 			if code == dhcpv6.OptionBootfileURL {
 				// bootfile URL is requested


### PR DESCRIPTION
This started as an implementation of #36, then I added a couple tests and saw that the RFC is much stricter than just "reject when ServerID is present and mismatched"

I'm not sure about patch 3 (Abort when ServerID is nil) since there may be a usecase for modifying the ServerID variables from outside the plugin that I didn't consider.

Commit messages have more details on individual commits, commits 1 and 6 are bugfixes

