### PR TITLE
Stop returning `nil, false` in plugins

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -11,8 +11,8 @@ import (
 // The two input packets are the original request, and a response packet.
 // The response packet may or may not be modified by the function, and
 // the result will be returned by the handler.
-// If the returned boolean is false, the returned packet may be nil or
-// invalid.
+// If the returned boolean is true, the returned packet may be nil or
+// invalid, in which case no response will be sent.
 type Handler6 func(req, resp dhcpv6.DHCPv6) (dhcpv6.DHCPv6, bool)
 
 // Handler4 behaves like Handler6, but for DHCPv4 packets.

--- a/plugins/file/plugin.go
+++ b/plugins/file/plugin.go
@@ -121,14 +121,15 @@ func LoadDHCPv6Records(filename string) (map[string]net.IP, error) {
 func Handler6(req, resp dhcpv6.DHCPv6) (dhcpv6.DHCPv6, bool) {
 	mac, err := dhcpv6.ExtractMAC(req)
 	if err != nil {
-		return nil, false
+		log.Warningf("Could not find client MAC, passing")
+		return resp, false
 	}
 	log.Printf("looking up an IP address for MAC %s", mac.String())
 
 	ipaddr, ok := StaticRecords[mac.String()]
 	if !ok {
 		log.Warningf("MAC address %s is unknown", mac.String())
-		return nil, false
+		return resp, false
 	}
 	log.Printf("found IP address %s for MAC %s", ipaddr, mac.String())
 	resp.AddOption(&dhcpv6.OptIANA{
@@ -167,6 +168,7 @@ func Handler6(req, resp dhcpv6.DHCPv6) (dhcpv6.DHCPv6, bool) {
 			}
 		}
 	}
+	// XXX: We should maybe allow other plugins to run after this to add other options/handle non-IANA requests
 	return resp, true
 }
 

--- a/plugins/server_id/plugin.go
+++ b/plugins/server_id/plugin.go
@@ -29,7 +29,7 @@ var (
 func Handler6(req, resp dhcpv6.DHCPv6) (dhcpv6.DHCPv6, bool) {
 	if v6ServerID == nil {
 		log.Fatal("BUG: Plugin is running uninitialized!")
-		return resp, false
+		return nil, true
 	}
 
 	msg, err := req.GetInnerMessage()
@@ -70,8 +70,9 @@ func Handler6(req, resp dhcpv6.DHCPv6) (dhcpv6.DHCPv6, bool) {
 
 // Handler4 handles DHCPv4 packets for the server_id plugin.
 func Handler4(req, resp *dhcpv4.DHCPv4) (*dhcpv4.DHCPv4, bool) {
-	if v4ServerID == nil || resp == nil {
-		return resp, false
+	if v4ServerID == nil {
+		log.Fatal("BUG: Plugin is running uninitialized!")
+		return nil, true
 	}
 	if req.OpCode != dhcpv4.OpcodeBootRequest {
 		log.Warningf("not a BootRequest, ignoring")


### PR DESCRIPTION
`return nil, false` in a plugin handler passes a nil dhcp message to the next plugin in the chain, which is almost guaranteed to crash or fail in some other way. The proper way to ignore a valid message (because we don't know what to do with it in this specific plugin) is to return the resp argument unmodified.

I think the documentation of handler was incorrect on this point and possibly misleading, but I'd appreciate if reviewers could double-check that my changes to the doc comment in handler.go make sense ?

Open question: Should maybe MainHandler[46] check for this as well and throw warning/errors/abort processing when receiving `nil, false` ? I can easily add that; but maybe a test or some sort of linter rule is better than checking at runtime