### PR TITLE
Allow listening on multiple addresses 

### DIFF
--- a/cmds/coredhcp/config.yml.example
+++ b/cmds/coredhcp/config.yml.example
@@ -1,14 +1,16 @@
 server6:
-    interface: "eth0"
-    #listen: 'your-unicast-address:547'
+    # Optionally add a listen statement as follows
+    # listen:
+        # - "[ff02::1:2]" # Listens on a link-local multicast address on all interfaces
+        # - "[fe80::1%eth0]:547" # Listens on a specific interface
+        # - "[::]" # Listens on the wildcard address. *No multicast group will be joined*
+    # Otherwise the default is ff02::1:2 on all interfaces and ff05::1:3 on the default multicast interface
     plugins:
         - server_id: LL 00:de:ad:be:ef:00
         - file: "leases.txt"
         # - dns: 2001:4860:4860::8888 2001:4860:4860::8844
 
 server4:
-    listen: '0.0.0.0:67'
-    interface: "eth0"
     plugins:
         # - lease_time: 60s
         # - server_id: 10.10.10.1

--- a/cmds/coredhcp/main.go
+++ b/cmds/coredhcp/main.go
@@ -10,9 +10,10 @@ import (
 	"io/ioutil"
 	"time"
 
-	"github.com/coredhcp/coredhcp"
 	"github.com/coredhcp/coredhcp/config"
 	"github.com/coredhcp/coredhcp/logger"
+	"github.com/coredhcp/coredhcp/server"
+
 	"github.com/coredhcp/coredhcp/plugins"
 	"github.com/coredhcp/coredhcp/plugins/dns"
 	"github.com/coredhcp/coredhcp/plugins/file"
@@ -88,12 +89,12 @@ func main() {
 	}
 
 	// start server
-	server := coredhcp.NewServer(config)
-	if err := server.Start(); err != nil {
-		log.Fatalf("Failed to start server: %v", err)
+	srv := server.NewServer(config)
+	if err := srv.Start(); err != nil {
+		log.Fatal(err)
 	}
-	if err := server.Wait(); err != nil {
-		log.Error(err)
+	if err := srv.Wait(); err != nil {
+		log.Print(err)
 	}
 	time.Sleep(time.Second)
 }

--- a/cmds/coredhcp/main.go
+++ b/cmds/coredhcp/main.go
@@ -89,8 +89,8 @@ func main() {
 	}
 
 	// start server
-	srv := server.NewServer(config)
-	if err := srv.Start(); err != nil {
+	srv, err := server.Start(config)
+	if err != nil {
 		log.Fatal(err)
 	}
 	if err := srv.Wait(); err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -111,59 +111,77 @@ func parsePlugins(pluginList []interface{}) ([]*PluginConfig, error) {
 	return plugins, nil
 }
 
-func (c *Config) getInterface(ver protocolVersion) (string, error) {
-	if err := protoVersionCheck(ver); err != nil {
-		return "", err
+// BUG(Natolumin): listen specifications of the form `[ip6]%iface:port` or
+// `[ip6]%iface` are not supported, even though they are the default format of
+// the `ss` utility in linux. Use `[ip6%iface]:port` instead
+
+// splitHostPort splits an address of the form ip%zone:port into ip,zone and port.
+// It still returns if any of these are unset (unlike net.SplitHostPort which
+// returns an error if there is no port)
+func splitHostPort(hostport string) (ip string, zone string, port string, err error) {
+	ip, port, err = net.SplitHostPort(hostport)
+	if err != nil {
+		// Either there is no port, or a more serious error.
+		// Supply a synthetic port to differentiate cases
+		var altErr error
+		if ip, _, altErr = net.SplitHostPort(hostport + ":0"); altErr != nil {
+			// Invalid even with a fake port. Return the original error
+			return
+		}
+		err = nil
 	}
-	directive := fmt.Sprintf("server%d.interface", ver)
-	if exists := c.v.Get(directive); exists == nil {
-		return "", ConfigErrorFromString("dhcpv%d: missing `%s` directive", ver, directive)
+	if i := strings.LastIndexByte(ip, '%'); i >= 0 {
+		ip, zone = ip[:i], ip[i+1:]
 	}
-	ifname := c.v.GetString(directive)
-	if ifname == "" {
-		return "", ConfigErrorFromString("dhcpv%d: missing `%s` directive", ver, directive)
-	}
-	return ifname, nil
+	return
 }
 
 func (c *Config) getListenAddress(ver protocolVersion) (*net.UDPAddr, error) {
 	if err := protoVersionCheck(ver); err != nil {
 		return nil, err
 	}
+
 	addr := c.v.GetString(fmt.Sprintf("server%d.listen", ver))
-	if addr == "" {
-		// return default listener
-		if ver == protocolV6 {
-			return &net.UDPAddr{
-				IP:   net.IPv6unspecified,
-				Port: dhcpv6.DefaultServerPort,
-			}, nil
-		}
-		return &net.UDPAddr{
-			IP:   net.IPv4zero,
-			Port: dhcpv4.ServerPort,
-		}, nil
-	}
-	ipStr, portStr, err := net.SplitHostPort(addr)
+	ipStr, ifname, portStr, err := splitHostPort(addr)
 	if err != nil {
 		return nil, ConfigErrorFromString("dhcpv%d: %v", ver, err)
 	}
+
 	ip := net.ParseIP(ipStr)
+	if ipStr == "" {
+		switch ver {
+		case protocolV4:
+			ip = net.IPv4zero
+		case protocolV6:
+			ip = net.IPv6unspecified
+		}
+	}
 	if ip == nil {
-		return nil, ConfigErrorFromString("dhcpv%d: invalid IP address in `listen` directive", ver)
+		return nil, ConfigErrorFromString("dhcpv%d: invalid IP address in `listen` directive: %s", ver, ipStr)
 	}
-	if ver == protocolV6 && ip.To4() != nil {
-		return nil, ConfigErrorFromString("dhcpv%d: not a valid IPv6 address in `listen` directive", ver)
-	} else if ver == protocolV4 && ip.To4() == nil {
-		return nil, ConfigErrorFromString("dhcpv%d: not a valid IPv4 address in `listen` directive", ver)
+	if ip4 := ip.To4(); (ver == protocolV6 && ip4 != nil) || (ver == protocolV4 && ip4 == nil) {
+		return nil, ConfigErrorFromString("dhcpv%d: not a valid IPv%d address in `listen` directive", ver, ver)
 	}
-	port, err := strconv.Atoi(portStr)
-	if err != nil {
-		return nil, ConfigErrorFromString("dhcpv%d: invalid `listen` port", ver)
+
+	var port int
+	if portStr == "" {
+		switch ver {
+		case protocolV4:
+			port = dhcpv4.ServerPort
+		case protocolV6:
+			port = dhcpv6.DefaultServerPort
+		}
+	} else {
+		port, err = strconv.Atoi(portStr)
+		if err != nil {
+			return nil, ConfigErrorFromString("dhcpv%d: invalid `listen` port", ver)
+		}
 	}
+
 	listener := net.UDPAddr{
 		IP:   ip,
 		Port: port,
+		Zone: ifname,
 	}
 	return &listener, nil
 }
@@ -187,10 +205,6 @@ func (c *Config) parseConfig(ver protocolVersion) error {
 		// it is valid to have no server configuration defined
 		return nil
 	}
-	ifname, err := c.getInterface(ver)
-	if err != nil {
-		return err
-	}
 	listenAddr, err := c.getListenAddress(ver)
 	if err != nil {
 		return err
@@ -198,6 +212,7 @@ func (c *Config) parseConfig(ver protocolVersion) error {
 	if listenAddr == nil {
 		// no listener is configured, so `c.Server6` (or `c.Server4` if v4)
 		// will stay nil.
+		log.Warnf("DHCPv%d: server%d present but no listen address defined. The server will not be started", ver, ver)
 		return nil
 	}
 	// read plugin configuration
@@ -210,7 +225,7 @@ func (c *Config) parseConfig(ver protocolVersion) error {
 	}
 	sc := ServerConfig{
 		Listener:  listenAddr,
-		Interface: ifname,
+		Interface: listenAddr.Zone,
 		Plugins:   plugins,
 	}
 	if ver == protocolV6 {

--- a/config/config.go
+++ b/config/config.go
@@ -41,8 +41,8 @@ func New() *Config {
 // ServerConfig holds a server configuration that is specific to either the
 // DHCPv6 server or the DHCPv4 server.
 type ServerConfig struct {
-	Addresses []*net.UDPAddr
-	Plugins   []*PluginConfig
+	Addresses []net.UDPAddr
+	Plugins   []PluginConfig
 }
 
 // PluginConfig holds the configuration of a plugin
@@ -83,8 +83,8 @@ func protoVersionCheck(v protocolVersion) error {
 	return nil
 }
 
-func parsePlugins(pluginList []interface{}) ([]*PluginConfig, error) {
-	plugins := make([]*PluginConfig, 0)
+func parsePlugins(pluginList []interface{}) ([]PluginConfig, error) {
+	plugins := make([]PluginConfig, 0, len(pluginList))
 	for idx, val := range pluginList {
 		conf := cast.ToStringMap(val)
 		if conf == nil {
@@ -105,7 +105,7 @@ func parsePlugins(pluginList []interface{}) ([]*PluginConfig, error) {
 			args = strings.Fields(cast.ToString(v))
 			break
 		}
-		plugins = append(plugins, &PluginConfig{Name: name, Args: args})
+		plugins = append(plugins, PluginConfig{Name: name, Args: args})
 	}
 	return plugins, nil
 }
@@ -188,7 +188,7 @@ func (c *Config) getListenAddress(addr string, ver protocolVersion) (*net.UDPAdd
 	return &listener, nil
 }
 
-func (c *Config) getPlugins(ver protocolVersion) ([]*PluginConfig, error) {
+func (c *Config) getPlugins(ver protocolVersion) ([]PluginConfig, error) {
 	if err := protoVersionCheck(ver); err != nil {
 		return nil, err
 	}
@@ -222,13 +222,13 @@ func (c *Config) parseConfig(ver protocolVersion) error {
 		addrs = []string{cast.ToString(listen)}
 	}
 
-	listeners := []*net.UDPAddr{}
+	listeners := []net.UDPAddr{}
 	for _, a := range addrs {
 		listenAddr, err := c.getListenAddress(a, ver)
 		if err != nil {
 			return err
 		}
-		listeners = append(listeners, listenAddr)
+		listeners = append(listeners, *listenAddr)
 	}
 
 	sc := ServerConfig{

--- a/config/config.go
+++ b/config/config.go
@@ -294,6 +294,15 @@ func (c *Config) parseListen(ver protocolVersion) ([]net.UDPAddr, error) {
 	}
 
 	listen := c.v.Get(fmt.Sprintf("server%d.listen", ver))
+
+	// Provide an emulation of the old keyword "interface" to avoid breaking config files
+	if iface := c.v.Get(fmt.Sprintf("server%d.interface", ver)); iface != nil && listen != nil {
+		return nil, ConfigErrorFromString("interface is a deprecated alias for listen, " +
+			"both cannot be used at the same time. Choose one and remove the other.")
+	} else if iface != nil {
+		listen = "%" + cast.ToString(iface)
+	}
+
 	if listen == nil {
 		return defaultListen(ver)
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,52 @@
+// Copyright 2018-present the CoreDHCP Authors. All rights reserved
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package config
+
+import "testing"
+
+func TestSplitHostPort(t *testing.T) {
+	testcases := []struct {
+		hostport string
+		ip       string
+		zone     string
+		port     string
+		err      bool // Should return an error (ie true for err != nil)
+	}{
+		{"0.0.0.0:67", "0.0.0.0", "", "67", false},
+		{"192.0.2.0", "192.0.2.0", "", "", false},
+		{"192.0.2.9%eth0", "192.0.2.9", "eth0", "", false},
+		{"0.0.0.0%eth0:67", "0.0.0.0", "eth0", "67", false},
+		{"0.0.0.0:20%eth0:67", "0.0.0.0", "eth0", "67", true},
+		{"2001:db8::1:547", "", "", "547", true}, // [] mandatory for v6
+		{"[::]:547", "::", "", "547", false},
+		{"[fe80::1%eth0]", "fe80::1", "eth0", "", false},
+		{"[fe80::1]:eth1", "fe80::1", "", "eth1", false},             // no validation of ports in this function
+		{"fe80::1%eth0:547", "fe80::1", "eth0", "547", true},         // [] mandatory for v6 even with %zone
+		{"fe80::1%eth0", "fe80::1", "eth0", "547", true},             // [] mandatory for v6 even without port
+		{"[2001:db8::2]47", "fe80::1", "eth0", "547", true},          // garbage after []
+		{"[ff02::1:2]%srv_u:547", "ff02::1:2", "srv_u", "547", true}, // FIXME: Linux `ss` format, we should accept but net.SplitHostPort doesn't
+		{":http", "", "", "http", false},
+		{"%eth0:80", "", "eth0", "80", false},          // janky, but looks valid enough for "[::%eth0]:80" imo
+		{"%eth0", "", "eth0", "", false},               // janky
+		{"fe80::1]:80", "fe80::1", "", "80", true},     // unbalanced ]
+		{"fe80::1%eth0]", "fe80::1", "eth0", "", true}, // unbalanced ], no port
+		{"", "", "", "", false},                        // trivial case, still valid
+	}
+
+	for _, tc := range testcases {
+		ip, zone, port, err := splitHostPort(tc.hostport)
+		if tc.err != (err != nil) {
+			errState := "not "
+			if tc.err {
+				errState = ""
+			}
+			t.Errorf("Mismatched error state: %s should %serror (got err: %v)\n", tc.hostport, errState, err)
+			continue
+		}
+		if err == nil && (ip != tc.ip || zone != tc.zone || port != tc.port) {
+			t.Errorf("%s => \"%s\", \"%s\", \"%s\" expected \"%s\",\"%s\",\"%s\"\n", tc.hostport, ip, zone, port, tc.ip, tc.zone, tc.port)
+		}
+	}
+}

--- a/coredhcp.go
+++ b/coredhcp.go
@@ -103,6 +103,10 @@ func (s *Server) LoadPlugins(conf *config.Config) ([]*plugins.Plugin, []*plugins
 	return loadedPlugins6, loadedPlugins4, nil
 }
 
+// BUG(Natolumin): Servers not bound to a specific interface may send responses
+// on the wrong interface as they will use the default route.
+// See https://github.com/coredhcp/coredhcp/issues/52
+
 // MainHandler6 runs for every received DHCPv6 packet. It will run every
 // registered handler in sequence, and reply with the resulting response.
 // It will not reply if the resulting response is `nil`.

--- a/go.mod
+++ b/go.mod
@@ -18,4 +18,5 @@ require (
 	github.com/spf13/viper v1.4.0
 	github.com/u-root/u-root v6.0.0+incompatible // indirect
 	github.com/x-cray/logrus-prefixed-formatter v0.5.2 // indirect
+	golang.org/x/net v0.0.0-20190930134127-c5a3c61f89f3
 )

--- a/go.sum
+++ b/go.sum
@@ -303,6 +303,8 @@ golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190923162816-aa69164e4478 h1:l5EDrHhldLYb3ZRHDUhXF7Om7MvYXnkV9/iQNo1lX6g=
 golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20190930134127-c5a3c61f89f3 h1:6KET3Sqa7fkVfD63QnAM81ZeYg5n4HwApOJkufONnHA=
+golang.org/x/net v0.0.0-20190930134127-c5a3c61f89f3/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -7,6 +7,7 @@ package plugins
 import (
 	"errors"
 
+	"github.com/coredhcp/coredhcp/config"
 	"github.com/coredhcp/coredhcp/handler"
 	"github.com/coredhcp/coredhcp/logger"
 )
@@ -44,4 +45,70 @@ func RegisterPlugin(plugin *Plugin) error {
 	}
 	RegisteredPlugins[plugin.Name] = plugin
 	return nil
+}
+
+// LoadPlugins reads a Config object and loads the plugins as specified in the
+// `plugins` section, in order. For a plugin to be available, it must have been
+// previously registered with plugins.RegisterPlugin. This is normally done at
+// plugin import time.
+// This function returns the list of loaded v6 plugins, the list of loaded v4
+// plugins, and an error if any.
+func LoadPlugins(conf *config.Config) ([]handler.Handler4, []handler.Handler6, error) {
+	log.Print("Loading plugins...")
+	handlers4 := make([]handler.Handler4, 0)
+	handlers6 := make([]handler.Handler6, 0)
+
+	if conf.Server6 == nil && conf.Server4 == nil {
+		return nil, nil, errors.New("no configuration found for either DHCPv6 or DHCPv4")
+	}
+
+	// now load the plugins. We need to call its setup function with
+	// the arguments extracted above. The setup function is mapped in
+	// plugins.RegisteredPlugins .
+
+	// Load DHCPv6 plugins.
+	if conf.Server6 != nil {
+		for _, pluginConf := range conf.Server6.Plugins {
+			if plugin, ok := RegisteredPlugins[pluginConf.Name]; ok {
+				log.Printf("DHCPv6: loading plugin `%s`", pluginConf.Name)
+				if plugin.Setup6 == nil {
+					log.Warningf("DHCPv6: plugin `%s` has no setup function for DHCPv6", pluginConf.Name)
+					continue
+				}
+				h6, err := plugin.Setup6(pluginConf.Args...)
+				if err != nil {
+					return nil, nil, err
+				} else if h6 == nil {
+					return nil, nil, config.ConfigErrorFromString("no DHCPv6 handler for plugin %s", pluginConf.Name)
+				}
+				handlers6 = append(handlers6, h6)
+			} else {
+				return nil, nil, config.ConfigErrorFromString("DHCPv6: unknown plugin `%s`", pluginConf.Name)
+			}
+		}
+	}
+	// Load DHCPv4 plugins. Yes, duplicated code, there's not really much that
+	// can be deduplicated here.
+	if conf.Server4 != nil {
+		for _, pluginConf := range conf.Server4.Plugins {
+			if plugin, ok := RegisteredPlugins[pluginConf.Name]; ok {
+				log.Printf("DHCPv4: loading plugin `%s`", pluginConf.Name)
+				if plugin.Setup4 == nil {
+					log.Warningf("DHCPv4: plugin `%s` has no setup function for DHCPv4", pluginConf.Name)
+					continue
+				}
+				h4, err := plugin.Setup4(pluginConf.Args...)
+				if err != nil {
+					return nil, nil, err
+				} else if h4 == nil {
+					return nil, nil, config.ConfigErrorFromString("no DHCPv4 handler for plugin %s", pluginConf.Name)
+				}
+				handlers4 = append(handlers4, h4)
+			} else {
+				return nil, nil, config.ConfigErrorFromString("DHCPv4: unknown plugin `%s`", pluginConf.Name)
+			}
+		}
+	}
+
+	return handlers4, handlers6, nil
 }

--- a/server/handle.go
+++ b/server/handle.go
@@ -2,24 +2,19 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-package coredhcp
+package server
 
 import (
-	"errors"
 	"fmt"
 	"net"
 
 	"github.com/coredhcp/coredhcp/config"
 	"github.com/coredhcp/coredhcp/handler"
-	"github.com/coredhcp/coredhcp/logger"
-	"github.com/coredhcp/coredhcp/plugins"
 	"github.com/insomniacslk/dhcp/dhcpv4"
 	"github.com/insomniacslk/dhcp/dhcpv4/server4"
 	"github.com/insomniacslk/dhcp/dhcpv6"
 	"github.com/insomniacslk/dhcp/dhcpv6/server6"
 )
-
-var log = logger.GetLogger("coredhcp")
 
 // Server is a CoreDHCP server structure that holds information about
 // DHCPv6 and DHCPv4 servers, and their respective handlers.
@@ -30,77 +25,6 @@ type Server struct {
 	Servers6  []*server6.Server
 	Servers4  []*server4.Server
 	errors    chan error
-}
-
-// LoadPlugins reads a Config object and loads the plugins as specified in the
-// `plugins` section, in order. For a plugin to be available, it must have been
-// previously registered with plugins.RegisterPlugin. This is normally done at
-// plugin import time.
-// This function returns the list of loaded v6 plugins, the list of loaded v4
-// plugins, and an error if any.
-func (s *Server) LoadPlugins(conf *config.Config) ([]*plugins.Plugin, []*plugins.Plugin, error) {
-	log.Print("Loading plugins...")
-	loadedPlugins6 := make([]*plugins.Plugin, 0)
-	loadedPlugins4 := make([]*plugins.Plugin, 0)
-
-	if conf.Server6 == nil && conf.Server4 == nil {
-		return nil, nil, errors.New("no configuration found for either DHCPv6 or DHCPv4")
-	}
-
-	// now load the plugins. We need to call its setup function with
-	// the arguments extracted above. The setup function is mapped in
-	// plugins.RegisteredPlugins .
-
-	// Load DHCPv6 plugins.
-	if conf.Server6 != nil {
-		for _, pluginConf := range conf.Server6.Plugins {
-			if plugin, ok := plugins.RegisteredPlugins[pluginConf.Name]; ok {
-				log.Printf("DHCPv6: loading plugin `%s`", pluginConf.Name)
-				if plugin.Setup6 == nil {
-					log.Warningf("DHCPv6: plugin `%s` has no setup function for DHCPv6", pluginConf.Name)
-					continue
-				}
-				h6, err := plugin.Setup6(pluginConf.Args...)
-				if err != nil {
-					return nil, nil, err
-				}
-				loadedPlugins6 = append(loadedPlugins6, plugin)
-				if h6 == nil {
-					return nil, nil, config.ConfigErrorFromString("no DHCPv6 handler for plugin %s", pluginConf.Name)
-				}
-				s.Handlers6 = append(s.Handlers6, h6)
-			} else {
-				return nil, nil, config.ConfigErrorFromString("DHCPv6: unknown plugin `%s`", pluginConf.Name)
-			}
-		}
-	}
-	// Load DHCPv4 plugins. Yes, duplicated code, there's not really much that
-	// can be deduplicated here.
-	if conf.Server4 != nil {
-		for _, pluginConf := range conf.Server4.Plugins {
-			if plugin, ok := plugins.RegisteredPlugins[pluginConf.Name]; ok {
-				log.Printf("DHCPv4: loading plugin `%s`", pluginConf.Name)
-				if plugin.Setup4 == nil {
-					log.Warningf("DHCPv4: plugin `%s` has no setup function for DHCPv4", pluginConf.Name)
-					continue
-				}
-				h4, err := plugin.Setup4(pluginConf.Args...)
-				if err != nil {
-					return nil, nil, err
-				}
-				loadedPlugins4 = append(loadedPlugins4, plugin)
-				if h4 == nil {
-					return nil, nil, config.ConfigErrorFromString("no DHCPv4 handler for plugin %s", pluginConf.Name)
-				}
-				s.Handlers4 = append(s.Handlers4, h4)
-				//s.Handlers4 = append(s.Handlers4, h4)
-			} else {
-				return nil, nil, config.ConfigErrorFromString("DHCPv4: unknown plugin `%s`", pluginConf.Name)
-			}
-		}
-	}
-
-	return loadedPlugins6, loadedPlugins4, nil
 }
 
 // BUG(Natolumin): Servers not bound to a specific interface may send responses
@@ -232,68 +156,4 @@ func (s *Server) MainHandler4(conn net.PacketConn, _peer net.Addr, req *dhcpv4.D
 	} else {
 		log.Print("MainHandler4: dropping request because response is nil")
 	}
-}
-
-// Start will start the server asynchronously. See `Wait` to wait until
-// the execution ends.
-func (s *Server) Start() error {
-	_, _, err := s.LoadPlugins(s.Config)
-	if err != nil {
-		return err
-	}
-
-	// listen
-	if s.Config.Server6 != nil {
-		log.Println("Starting DHCPv6 server")
-		for _, l := range s.Config.Server6.Addresses {
-			s6, err := server6.NewServer(l.Zone, l, s.MainHandler6)
-			if err != nil {
-				return err
-			}
-			s.Servers6 = append(s.Servers6, s6)
-			log.Infof("Listen %s", l)
-			go func() {
-				s.errors <- s6.Serve()
-			}()
-		}
-	}
-
-	if s.Config.Server4 != nil {
-		log.Println("Starting DHCPv4 server")
-		for _, l := range s.Config.Server4.Addresses {
-			s4, err := server4.NewServer(l.Zone, l, s.MainHandler4)
-			if err != nil {
-				return err
-			}
-			s.Servers4 = append(s.Servers4, s4)
-			log.Infof("Listen %s", l)
-			go func() {
-				s.errors <- s4.Serve()
-			}()
-		}
-	}
-
-	return nil
-}
-
-// Wait waits until the end of the execution of the server.
-func (s *Server) Wait() error {
-	log.Print("Waiting")
-	err := <-s.errors
-	for _, s6 := range s.Servers6 {
-		if s6 != nil {
-			s6.Close()
-		}
-	}
-	for _, s4 := range s.Servers4 {
-		if s4 != nil {
-			s4.Close()
-		}
-	}
-	return err
-}
-
-// NewServer creates a Server instance with the provided configuration.
-func NewServer(config *config.Config) *Server {
-	return &Server{Config: config, errors: make(chan error, 1)}
 }

--- a/server/serve.go
+++ b/server/serve.go
@@ -1,0 +1,81 @@
+// Copyright 2018-present the CoreDHCP Authors. All rights reserved
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package server
+
+import (
+	"github.com/coredhcp/coredhcp/config"
+	"github.com/coredhcp/coredhcp/logger"
+	"github.com/coredhcp/coredhcp/plugins"
+	"github.com/insomniacslk/dhcp/dhcpv4/server4"
+	"github.com/insomniacslk/dhcp/dhcpv6/server6"
+)
+
+var log = logger.GetLogger("server")
+
+// Start will start the server asynchronously. See `Wait` to wait until
+// the execution ends.
+func (s *Server) Start() error {
+	var err error
+
+	s.Handlers4, s.Handlers6, err = plugins.LoadPlugins(s.Config)
+	if err != nil {
+		return err
+	}
+
+	// listen
+	if s.Config.Server6 != nil {
+		log.Println("Starting DHCPv6 server")
+		for _, l := range s.Config.Server6.Addresses {
+			s6, err := server6.NewServer(l.Zone, l, s.MainHandler6)
+			if err != nil {
+				return err
+			}
+			s.Servers6 = append(s.Servers6, s6)
+			log.Infof("Listen %s", l)
+			go func() {
+				s.errors <- s6.Serve()
+			}()
+		}
+	}
+
+	if s.Config.Server4 != nil {
+		log.Println("Starting DHCPv4 server")
+		for _, l := range s.Config.Server4.Addresses {
+			s4, err := server4.NewServer(l.Zone, l, s.MainHandler4)
+			if err != nil {
+				return err
+			}
+			s.Servers4 = append(s.Servers4, s4)
+			log.Infof("Listen %s", l)
+			go func() {
+				s.errors <- s4.Serve()
+			}()
+		}
+	}
+
+	return nil
+}
+
+// Wait waits until the end of the execution of the server.
+func (s *Server) Wait() error {
+	log.Print("Waiting")
+	err := <-s.errors
+	for _, s6 := range s.Servers6 {
+		if s6 != nil {
+			s6.Close()
+		}
+	}
+	for _, s4 := range s.Servers4 {
+		if s4 != nil {
+			s4.Close()
+		}
+	}
+	return err
+}
+
+// NewServer creates a Server instance with the provided configuration.
+func NewServer(config *config.Config) *Server {
+	return &Server{Config: config, errors: make(chan error, 1)}
+}

--- a/server/serve.go
+++ b/server/serve.go
@@ -126,7 +126,7 @@ func Start(config *config.Config) (*Servers, error) {
 		log.Println("Starting DHCPv6 server")
 		for _, addr := range config.Server6.Addresses {
 			var l6 *listener6
-			l6, err = listen6(addr)
+			l6, err = listen6(&addr)
 			if err != nil {
 				goto cleanup
 			}
@@ -142,7 +142,7 @@ func Start(config *config.Config) (*Servers, error) {
 		log.Println("Starting DHCPv4 server")
 		for _, addr := range config.Server4.Addresses {
 			var l4 *listener4
-			l4, err = listen4(addr)
+			l4, err = listen4(&addr)
 			if err != nil {
 				goto cleanup
 			}


### PR DESCRIPTION
This implements the changes discussed in #52 

There is an additional remaining issue mentioned in https://github.com/coredhcp/coredhcp/issues/52#issuecomment-532621844 where, when listening on a socket that is not bound to an interface, reply packets, especially broadcast or link-local, may be sent on the wrong interface. 

I believe this is fixable as mentioned in the issue, so this is a draft until we decide on a solution (or decide this is fine for the moment and to commit this)

Individual commit messages have more information