### PR TITLE
[plugins/file] do not stop when an entry is found

### DIFF
--- a/plugins/file/plugin.go
+++ b/plugins/file/plugin.go
@@ -165,8 +165,7 @@ func Handler6(req, resp dhcpv6.DHCPv6) (dhcpv6.DHCPv6, bool) {
 			}
 		}
 	}
-	// XXX: We should maybe allow other plugins to run after this to add other options/handle non-IANA requests
-	return resp, true
+	return resp, false
 }
 
 // Handler4 handles DHCPv4 packets for the file plugin


### PR DESCRIPTION
The plugin currently stops when when an entry is found. This does not
let the following plugins to run, and it makes no sense.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>