### PR TITLE
travis: Enable go modules support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,16 @@ language: go
 sudo: required
 
 go:
-  - "1.11"
   - "1.12"
+  - "1.13"
   - tip
 
 env:
-  - TEST_SUITE=unit
-  - TEST_SUITE=linters
+  global:
+    - GO111MODULE=on
+  matrix:
+    - TEST_SUITE=unit
+    - TEST_SUITE=linters
 
 before_install:
   - go get -t -v ./...


### PR DESCRIPTION
Currently, go.mod is ineffective in travis since the default value is GO111MODULE=auto and travis runs go builds in GOPATH, making the auto value translate to off. For example there was a breaking change in the upstream dhcp library that we didn't take in yet, but it's breaking builds anyway

This enables modules unconditionally, as well as go 1.13 which has been released, and removes go 1.11 because our go.mod states go 1.12 as minimum version