### PR TITLE
Add -logfile and -nostdout flags for logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
 	github.com/onsi/ginkgo v1.9.0 // indirect
 	github.com/onsi/gomega v1.6.0 // indirect
+	github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cast v1.3.0
 	github.com/spf13/viper v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -100,6 +100,8 @@ github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5 h1:mZHayPoR0lNmnHyvtYjDeq0zlVHn9K/ZXoy17ylucdo=
+github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5/go.mod h1:GEXHk5HgEKCvEIIrSpFI3ozzG5xOKA2DVlEX/gGnewM=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -5,9 +5,11 @@
 package logger
 
 import (
+	"io/ioutil"
 	"sync"
 
 	log_prefixed "github.com/chappjc/logrus-prefix"
+	"github.com/rifflock/lfshook"
 	"github.com/sirupsen/logrus"
 )
 
@@ -31,4 +33,14 @@ func GetLogger(prefix string) *logrus.Entry {
 		globalLogger = logger
 	}
 	return globalLogger.WithField("prefix", prefix)
+}
+
+// WithFile logs to the specified file in addition to the existing output.
+func WithFile(log *logrus.Entry, logfile string) {
+	log.Logger.AddHook(lfshook.NewHook(logfile, &logrus.TextFormatter{}))
+}
+
+// WithNoStdOutErr disables logging to stdout/stderr.
+func WithNoStdOutErr(log *logrus.Entry) {
+	log.Logger.SetOutput(ioutil.Discard)
 }


### PR DESCRIPTION
This commit adds two flags:
* -logfile, to enable logging to file as additional destination
* -nostdout, to disable logging to stdout

Disabing logging to stdout can help improving QPS in certain setups.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>