### PR TITLE
Relay reply

### DIFF
--- a/coredhcp.go
+++ b/coredhcp.go
@@ -160,7 +160,14 @@ func (s *Server) MainHandler6(conn net.PacketConn, peer net.Addr, req dhcpv6.DHC
 		resp = tmp
 	}
 
-	if _, err := conn.WriteTo(resp.ToBytes(), peer); err != nil {
+	var newPeer = peer
+	if req.IsRelay() {
+		newPeer = &net.UDPAddr{
+			IP:   peer.(*net.UDPAddr).IP,
+			Port: dhcpv6.DefaultServerPort,
+		}
+	}
+	if _, err := conn.WriteTo(resp.ToBytes(), newPeer); err != nil {
 		log.Printf("MainHandler6: conn.Write to %v failed: %v", peer, err)
 	}
 }


### PR DESCRIPTION
If the request comes from an ephemeral source port, the server will
reply on such port. However the relay will be listening on server port
instead, so the reply is dropped. With this patch the reply always goes
to the server port if the request is a relay.
