### PR TITLE
Add -debug flag

### DIFF
--- a/cmds/coredhcp/main.go
+++ b/cmds/coredhcp/main.go
@@ -17,16 +17,22 @@ import (
 	_ "github.com/coredhcp/coredhcp/plugins/range"
 	_ "github.com/coredhcp/coredhcp/plugins/router"
 	_ "github.com/coredhcp/coredhcp/plugins/server_id"
+	"github.com/sirupsen/logrus"
 )
 
 var (
 	flagLogFile     = flag.String("logfile", "", "Name of the log file to append to. Default: stdout/stderr only")
 	flagLogNoStdout = flag.Bool("nostdout", false, "Disable logging to stdout/stderr")
+	flagDebug       = flag.Bool("debug", false, "Enable debug output")
 )
 
 func main() {
 	flag.Parse()
 	log := logger.GetLogger("main")
+	if *flagDebug {
+		log.Logger.SetLevel(logrus.DebugLevel)
+		log.Infof("Enabled debug logging")
+	}
 	if *flagLogFile != "" {
 		log.Infof("Logging to file %s", *flagLogFile)
 		logger.WithFile(log, *flagLogFile)


### PR DESCRIPTION
When passed, it will enable debug logging. Currently we don't log
anything at debug level, but since logging proved to be a potential
bottleneck we can move less important messages to debug level.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>