### PR TITLE
Revert "Relay reply"

### DIFF
--- a/coredhcp.go
+++ b/coredhcp.go
@@ -160,14 +160,7 @@ func (s *Server) MainHandler6(conn net.PacketConn, peer net.Addr, req dhcpv6.DHC
 		resp = tmp
 	}
 
-	var newPeer = peer
-	if req.IsRelay() {
-		newPeer = &net.UDPAddr{
-			IP:   peer.(*net.UDPAddr).IP,
-			Port: dhcpv6.DefaultServerPort,
-		}
-	}
-	if _, err := conn.WriteTo(resp.ToBytes(), newPeer); err != nil {
+	if _, err := conn.WriteTo(resp.ToBytes(), peer); err != nil {
 		log.Printf("MainHandler6: conn.Write to %v failed: %v", peer, err)
 	}
 }


### PR DESCRIPTION
Reverts coredhcp/coredhcp#67

Copying the relevant portion of the RFC from https://github.com/coredhcp/coredhcp/pull/67#issuecomment-557078623: 
> Relay agents implementing this specification may be configured
instead to 1) use a source port number other than 547 when relaying
messages toward servers and 2) receive responses toward clients on
that same port.

Lower down: 
>Additionally, the IPv6 server MUST check and
   use the UDP source port from the UDP packet of the Relay-forward
   message in replying to the relay agent.