### PR TITLE
[cmds/contest] Redis plugin is not compiled by default

### DIFF
--- a/cmds/coredhcp/main.go
+++ b/cmds/coredhcp/main.go
@@ -18,7 +18,6 @@ import (
 	_ "github.com/coredhcp/coredhcp/plugins/range"
 	_ "github.com/coredhcp/coredhcp/plugins/router"
 	_ "github.com/coredhcp/coredhcp/plugins/server_id"
-	_ "github.com/coredhcp/plugins/redis"
 	"github.com/sirupsen/logrus"
 )
 


### PR DESCRIPTION
Not every installation needs the Redis plugin, so we moved it out of
the core plugins, and this patch also stops compiling it by default,
reducing dependencies and binary size of the default cmd.
To compile the redis plugin and other plugins, use
cmds/coredhcp-generator.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>