### PR TITLE
RFC/PoC: Support for dynamic plugin loading

### DIFF
--- a/cmds/coredhcp/config.yml.example
+++ b/cmds/coredhcp/config.yml.example
@@ -16,3 +16,5 @@ server4:
         # - router: 10.10.10.1
         # - netmask: 255.255.255.0
         # - range: leases.txt 10.10.10.100 10.10.10.200 60s
+
+dynamic_plugins: /usr/lib64/coredhcp/plugins

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,7 @@ go 1.12
 
 require (
 	github.com/chappjc/logrus-prefix v0.0.0-20180227015900-3a1d64819adb
-	github.com/coredhcp/plugins v0.0.0-20191121175107-a201c0b24a48
 	github.com/golangci/golangci-lint v1.21.0 // indirect
-	github.com/gomodule/redigo v2.0.0+incompatible
 	github.com/hugelgupf/socketpair v0.0.0-20190730060125-05d35a94e714 // indirect
 	github.com/insomniacslk/dhcp v0.0.0-20191112140002-c05874014012
 	github.com/mdlayher/ethernet v0.0.0-20190606142754-0394541c37b7 // indirect

--- a/internal/dynplugins/dynamic.go
+++ b/internal/dynplugins/dynamic.go
@@ -1,0 +1,39 @@
+// Copyright 2018-present the CoreDHCP Authors. All rights reserved
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package dynplugins
+
+import (
+	"errors"
+	"fmt"
+	"path"
+	"plugin"
+
+	"github.com/coredhcp/coredhcp/plugins"
+)
+
+// LoadDynamic attempts to load the plugin pluginName in the given location
+func LoadDynamic(location, pluginName string) error {
+	if location == "" {
+		return errors.New("dynamic plugin loading is disabled")
+	}
+	if _, ok := plugins.RegisteredPlugins[pluginName]; ok {
+		// Plugin is already loaded or builtin
+		return nil
+	}
+
+	pluginFile := fmt.Sprintf("plugin_%s.so", pluginName)
+	_, err := plugin.Open(path.Join(location, pluginFile))
+	if err != nil {
+		return fmt.Errorf("could not load dynamic plugin %s: %v", pluginName, err)
+	}
+
+	// At the moment, plugins register themselves in their init. Nothing to
+	// call, but we can check it registered itself on load properly
+	if _, ok := plugins.RegisteredPlugins[pluginName]; !ok {
+		return fmt.Errorf("loaded plugin %s did not register itself", pluginName)
+	}
+
+	return nil
+}


### PR DESCRIPTION
On linux and macOS, go supports building shared objects and loading them at runtime. This PR adds support in coredhcp for loading these, in the style of C/C++ dynamic plugins found in many server projects.

If this idea is ok, I'll work on some build tooling and additional documentation

## Instructions : 
* change the package name for the plugin to `main` (required to build as plugin)
* build the plugin (either in-tree or out-of-tree) with `go build -buildmode=plugin`. Rename it to `plugin_<name>.so`
* add the directory where your .so is in the config.yml as a top-level object:
  ```yaml
  dynamic_plugins: /home/coredhcp/plugins
  ```
  And load the plugin in one of your server statements
* **remove** the plugin from the `import` statement in `cmd/coredhcp/main.go` or in the file generated by coredhcp-generator
* run coredhcp, the plugin should load as if it were builtin

## Troubleshooting

You will most probably encounter the following error (don't forget to run with `-debug` until it works):
```
DEBUG coredhcp: Attempted to load plugin redis dynamically: could not load dynamic plugin redis: plugin.Open("coredhcp-plugins/plugin_redis"): plugin was built with a different version of package golang.org/x/sys/unix
```
Any package version mismatch will cause issues. At the moment both coredhcp/plugins and insomniacslk/dhcp do not use go modules, and building these libraries will use whatever version of dependencies you have in your gopath.
To help with this during local development, you can: 
1. run `go mod init` in both your repositories for `github.com/insomniacslk/dhcp` and `github.com/coredhcp/plugins`
1. add the following replace statements in the go.mod files:
  ```go
  // In coredhcp/coredhcp/go.mod
  replace github.com/insomniacslk/dhcp => <path to your checkout of insomniacslk/dhcp>
  // in coredhcp/plugins/go.mod
  replace (
          github.com/coredhcp/coredhcp => <path to your checkout of coredhcp>
          github.com/insomniacslk/dhcp => <path to your checkout of insomniacslk/dhcp>
  )
  ```

## Caveats
**This is not a replacement for coredhp-generator and fixing static build**
It is only supported: 
 * On linux and macOS
 * With cgo
 * When all included packages are the same versions (modules can somewhat help here)

It requires some additional tooling to build (changing packages for plugins to "main" for example)