### PR TITLE
plugin/file: Update for breaking changes in insomniacslk/dhcp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/golangci/golangci-lint v1.21.0 // indirect
 	github.com/gomodule/redigo v2.0.0+incompatible
 	github.com/hugelgupf/socketpair v0.0.0-20190730060125-05d35a94e714 // indirect
-	github.com/insomniacslk/dhcp v0.0.0-20191112140002-c05874014012
+	github.com/insomniacslk/dhcp v0.0.0-20200102182701-53297fb6d37d
 	github.com/mdlayher/ethernet v0.0.0-20190606142754-0394541c37b7 // indirect
 	github.com/mdlayher/raw v0.0.0-20190606144222-a54781e5f38f // indirect
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect

--- a/go.sum
+++ b/go.sum
@@ -133,6 +133,8 @@ github.com/insomniacslk/dhcp v0.0.0-20191002211418-651e0846f780 h1:ty8rDh2kTAoxe
 github.com/insomniacslk/dhcp v0.0.0-20191002211418-651e0846f780/go.mod h1:CfMdguCK66I5DAUJgGKyNz8aB6vO5dZzkm9Xep6WGvw=
 github.com/insomniacslk/dhcp v0.0.0-20191112140002-c05874014012 h1:FPWfO4cQp0BS5WKI9Yoak1IlPNU9IUzGUmFZEfVG7V4=
 github.com/insomniacslk/dhcp v0.0.0-20191112140002-c05874014012/go.mod h1:CfMdguCK66I5DAUJgGKyNz8aB6vO5dZzkm9Xep6WGvw=
+github.com/insomniacslk/dhcp v0.0.0-20200102182701-53297fb6d37d h1:KwAJbjTsU1uPLQOrlfImYEhTGXJQSKFTgRExKgSp4ec=
+github.com/insomniacslk/dhcp v0.0.0-20200102182701-53297fb6d37d/go.mod h1:CfMdguCK66I5DAUJgGKyNz8aB6vO5dZzkm9Xep6WGvw=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=

--- a/plugins/file/plugin.go
+++ b/plugins/file/plugin.go
@@ -31,6 +31,7 @@ import (
 	"io/ioutil"
 	"net"
 	"strings"
+	"time"
 
 	"github.com/coredhcp/coredhcp/handler"
 	"github.com/coredhcp/coredhcp/logger"
@@ -142,8 +143,8 @@ func Handler6(req, resp dhcpv6.DHCPv6) (dhcpv6.DHCPv6, bool) {
 		Options: []dhcpv6.Option{
 			&dhcpv6.OptIAAddress{
 				IPv6Addr:          ipaddr,
-				PreferredLifetime: 3600,
-				ValidLifetime:     3600,
+				PreferredLifetime: 3600 * time.Second,
+				ValidLifetime:     3600 * time.Second,
 			},
 		},
 	})


### PR DESCRIPTION
https://github.com/insomniacslk/dhcp/pull/347 changed struct
OptIAAddress to use time.Duration for lifetimes. This is a breaking
change and users need to update.

Note that it still compiles without the changes as time.Duration is an
int64, but the values become incorrect (3600 ns rounded as 0s, instead of 3600s)