### PR TITLE
serverid: fix v4ServerID copy

### DIFF
--- a/plugins/serverid/plugin.go
+++ b/plugins/serverid/plugin.go
@@ -110,7 +110,7 @@ func setup4(args ...string) (handler.Handler4, error) {
 	if serverID.To4() == nil {
 		return nil, errors.New("not a valid IPv4 address")
 	}
-	v4ServerID = serverID
+	v4ServerID = serverID.To4()
 	return Handler4, nil
 }
 


### PR DESCRIPTION
I am not very familiar with net.IP, but copying the first 4 bytes of
a v4 net.IP currently result in 0.0.0.0.

Signed-off-by: Marc-André Lureau <marcandre.lureau@redhat.com>