### PR TITLE
plugins/netmask: Don't panic on invalid netmask

### DIFF
--- a/plugins/netmask/plugin.go
+++ b/plugins/netmask/plugin.go
@@ -38,19 +38,19 @@ func setup6(args ...string) (handler.Handler6, error) {
 func setup4(args ...string) (handler.Handler4, error) {
 	log.Printf("loaded plugin for DHCPv4.")
 	if len(args) != 1 {
-		return nil, errors.New("need at least one netmask IP address")
+		return nil, errors.New("need exactly one netmask IP address")
 	}
 	netmaskIP := net.ParseIP(args[0])
 	if netmaskIP.IsUnspecified() {
-		return nil, errors.New("netmask is not valid, got: " + args[1])
+		return nil, errors.New("netmask is unspecified, got: " + args[0])
 	}
 	netmaskIP = netmaskIP.To4()
 	if netmaskIP == nil {
-		return nil, errors.New("expected an netmask address, got: " + args[1])
+		return nil, errors.New("expected a v4 netmask address, got: " + args[0])
 	}
 	netmask = net.IPv4Mask(netmaskIP[0], netmaskIP[1], netmaskIP[2], netmaskIP[3])
 	if !checkValidNetmask(netmask) {
-		return nil, errors.New("netmask is not valid, got: " + args[1])
+		return nil, errors.New("netmask is not valid, got: " + args[0])
 	}
 	log.Printf("loaded client netmask")
 	return Handler4, nil


### PR DESCRIPTION
It looks like the error handling for this plugin is borked. I noticed
this while reading this code during my attempt to implement a DHCP
server. This also clarifies the error messages, since they were either
innaccurate, or duplicated which would make it impossible to tell which
code path the error actually came from.

NOTE: I didn't test this code, but it seems pretty trivial. I hope you have CI, but since this bug got through, then maybe not?