### PR TITLE
Update dhcp library to latest upstream and use the new getters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/golangci/golangci-lint v1.21.0 // indirect
 	github.com/gomodule/redigo v2.0.0+incompatible
 	github.com/hugelgupf/socketpair v0.0.0-20190730060125-05d35a94e714 // indirect
-	github.com/insomniacslk/dhcp v0.0.0-20200102182701-53297fb6d37d
+	github.com/insomniacslk/dhcp v0.0.0-20200420235442-ed3125c2efe7
 	github.com/mdlayher/ethernet v0.0.0-20190606142754-0394541c37b7 // indirect
 	github.com/mdlayher/raw v0.0.0-20190606144222-a54781e5f38f // indirect
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,8 @@ github.com/insomniacslk/dhcp v0.0.0-20191112140002-c05874014012 h1:FPWfO4cQp0BS5
 github.com/insomniacslk/dhcp v0.0.0-20191112140002-c05874014012/go.mod h1:CfMdguCK66I5DAUJgGKyNz8aB6vO5dZzkm9Xep6WGvw=
 github.com/insomniacslk/dhcp v0.0.0-20200102182701-53297fb6d37d h1:KwAJbjTsU1uPLQOrlfImYEhTGXJQSKFTgRExKgSp4ec=
 github.com/insomniacslk/dhcp v0.0.0-20200102182701-53297fb6d37d/go.mod h1:CfMdguCK66I5DAUJgGKyNz8aB6vO5dZzkm9Xep6WGvw=
+github.com/insomniacslk/dhcp v0.0.0-20200420235442-ed3125c2efe7 h1:iaCm+9nZdYb8XCSU2TfIb0qYTcAlIv2XzyKR2d2xZ38=
+github.com/insomniacslk/dhcp v0.0.0-20200420235442-ed3125c2efe7/go.mod h1:CfMdguCK66I5DAUJgGKyNz8aB6vO5dZzkm9Xep6WGvw=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=

--- a/plugins/dns/plugin.go
+++ b/plugins/dns/plugin.go
@@ -69,7 +69,7 @@ func Handler6(req, resp dhcpv6.DHCPv6) (dhcpv6.DHCPv6, bool) {
 	}
 
 	if decap.IsOptionRequested(dhcpv6.OptionDNSRecursiveNameServer) {
-		resp.UpdateOption(&dhcpv6.OptDNSRecursiveNameServer{NameServers: dnsServers6})
+		resp.UpdateOption(dhcpv6.OptDNS(dnsServers6...))
 	}
 	return resp, false
 }

--- a/plugins/dns/plugin_test.go
+++ b/plugins/dns/plugin_test.go
@@ -18,9 +18,7 @@ func TestAddServer6(t *testing.T) {
 		t.Fatal(err)
 	}
 	req.MessageType = dhcpv6.MessageTypeRequest
-	oro := dhcpv6.OptRequestedOption{}
-	oro.AddRequestedOption(dhcpv6.OptionDNSRecursiveNameServer)
-	req.AddOption(&oro)
+	req.AddOption(dhcpv6.OptRequestedOption(dhcpv6.OptionDNSRecursiveNameServer))
 
 	stub, err := dhcpv6.NewMessage()
 	if err != nil {
@@ -45,7 +43,7 @@ func TestAddServer6(t *testing.T) {
 	if len(opts) != 1 {
 		t.Fatalf("Expected 1 RDNSS option, got %d: %v", len(opts), opts)
 	}
-	foundServers := opts[0].(*dhcpv6.OptDNSRecursiveNameServer).NameServers
+	foundServers := resp.(*dhcpv6.Message).Options.DNS()
 	// XXX: is enforcing the order relevant here ?
 	for i, srv := range foundServers {
 		if !srv.Equal(dnsServers6[i]) {
@@ -63,7 +61,7 @@ func TestNotRequested6(t *testing.T) {
 		t.Fatal(err)
 	}
 	req.MessageType = dhcpv6.MessageTypeRequest
-	req.AddOption(&dhcpv6.OptRequestedOption{})
+	req.AddOption(dhcpv6.OptRequestedOption())
 
 	stub, err := dhcpv6.NewMessage()
 	if err != nil {

--- a/plugins/file/plugin.go
+++ b/plugins/file/plugin.go
@@ -143,13 +143,13 @@ func Handler6(req, resp dhcpv6.DHCPv6) (dhcpv6.DHCPv6, bool) {
 	resp.AddOption(&dhcpv6.OptIANA{
 		// FIXME copy this field from the client, reject/drop if missing
 		IaId: [4]byte{0xaa, 0xbb, 0xcc, 0xdd},
-		Options: []dhcpv6.Option{
+		Options: dhcpv6.IdentityOptions{Options: []dhcpv6.Option{
 			&dhcpv6.OptIAAddress{
 				IPv6Addr:          ipaddr,
 				PreferredLifetime: 3600 * time.Second,
 				ValidLifetime:     3600 * time.Second,
 			},
-		},
+		}},
 	})
 	return resp, false
 }

--- a/plugins/nbp/nbp.go
+++ b/plugins/nbp/nbp.go
@@ -101,16 +101,14 @@ func nbpHandler6(req, resp dhcpv6.DHCPv6) (dhcpv6.DHCPv6, bool) {
 		// drop the request, this is probably a critical error in the packet.
 		return nil, true
 	}
-	if oro := decap.GetOption(dhcpv6.OptionORO); len(oro) > 0 {
-		for _, code := range oro[0].(*dhcpv6.OptRequestedOption).RequestedOptions() {
-			if code == dhcpv6.OptionBootfileURL {
-				// bootfile URL is requested
-				resp.AddOption(opt59)
-			} else if code == dhcpv6.OptionBootfileParam {
-				// optionally add opt60, bootfile params, if requested
-				if opt60 != nil {
-					resp.AddOption(opt60)
-				}
+	for _, code := range decap.Options.RequestedOptions() {
+		if code == dhcpv6.OptionBootfileURL {
+			// bootfile URL is requested
+			resp.AddOption(opt59)
+		} else if code == dhcpv6.OptionBootfileParam {
+			// optionally add opt60, bootfile params, if requested
+			if opt60 != nil {
+				resp.AddOption(opt60)
 			}
 		}
 	}

--- a/plugins/serverid/plugin_test.go
+++ b/plugins/serverid/plugin_test.go
@@ -88,13 +88,10 @@ func TestAddServerIDV6(t *testing.T) {
 		t.Fatal("plugin did not return an answer")
 	}
 
-	if opt := resp.GetOneOption(dhcpv6.OptionServerID); opt == nil {
+	if opt := resp.(*dhcpv6.Message).Options.ServerID(); opt == nil {
 		t.Fatal("plugin did not add a ServerID option")
-	} else {
-		sid := opt.(*dhcpv6.OptServerId)
-		if !sid.Sid.Equal(*v6ServerID) {
-			t.Fatalf("Got unexpected DUID: expected %v, got %v", v6ServerID, sid.Sid)
-		}
+	} else if !opt.Equal(*v6ServerID) {
+		t.Fatalf("Got unexpected DUID: expected %v, got %v", v6ServerID, opt)
 	}
 }
 


### PR DESCRIPTION
There were many changes in the interfaces with the introduction of the
getters in the upstream library. I've fixed the compilation failures so the code compiles, but not attempted to improve it to use the getters otherwise