### PR TITLE
config: Allow overriding config location from flags

### DIFF
--- a/cmds/coredhcp-generator/coredhcp.go.template
+++ b/cmds/coredhcp-generator/coredhcp.go.template
@@ -31,6 +31,7 @@ var (
 	flagLogFile     = flag.String("logfile", "", "Name of the log file to append to. Default: stdout/stderr only")
 	flagLogNoStdout = flag.Bool("nostdout", false, "Disable logging to stdout/stderr")
 	flagLogLevel    = flag.String("loglevel", "info", fmt.Sprintf("Log level. One of %v", getLogLevels()))
+	flagConfig      = flag.String("conf", "", "Use this configuration file instead of the default location")
 )
 
 var logLevels = map[string]func(*logrus.Logger){
@@ -73,7 +74,7 @@ func main() {
 		log.Infof("Disabling logging to stdout/stderr")
 		logger.WithNoStdOutErr(log)
 	}
-	config, err := config.Load()
+	config, err := config.Load(*flagConfig)
 	if err != nil {
 		log.Fatalf("Failed to load configuration: %v", err)
 	}

--- a/cmds/coredhcp/main.go
+++ b/cmds/coredhcp/main.go
@@ -34,6 +34,7 @@ var (
 	flagLogFile     = flag.String("logfile", "", "Name of the log file to append to. Default: stdout/stderr only")
 	flagLogNoStdout = flag.Bool("nostdout", false, "Disable logging to stdout/stderr")
 	flagLogLevel    = flag.String("loglevel", "info", fmt.Sprintf("Log level. One of %v", getLogLevels()))
+	flagConfig      = flag.String("conf", "", "Use this configuration file instead of the default location")
 )
 
 var logLevels = map[string]func(*logrus.Logger){
@@ -81,7 +82,7 @@ func main() {
 		log.Infof("Disabling logging to stdout/stderr")
 		logger.WithNoStdOutErr(log)
 	}
-	config, err := config.Load()
+	config, err := config.Load(*flagConfig)
 	if err != nil {
 		log.Fatalf("Failed to load configuration: %v", err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -54,14 +54,20 @@ type PluginConfig struct {
 
 // Load reads a configuration file and returns a Config object, or an error if
 // any.
-func Load() (*Config, error) {
+func Load(pathOverride string) (*Config, error) {
 	log.Print("Loading configuration")
 	c := New()
 	c.v.SetConfigType("yml")
-	c.v.SetConfigName("config")
-	c.v.AddConfigPath(".")
-	c.v.AddConfigPath("$HOME/.coredhcp/")
-	c.v.AddConfigPath("/etc/coredhcp/")
+	if pathOverride != "" {
+		c.v.SetConfigFile(pathOverride)
+	} else {
+		c.v.SetConfigName("config")
+		c.v.AddConfigPath(".")
+		c.v.AddConfigPath("$XDG_CONFIG_HOME/coredhcp/")
+		c.v.AddConfigPath("$HOME/.coredhcp/")
+		c.v.AddConfigPath("/etc/coredhcp/")
+	}
+
 	if err := c.v.ReadInConfig(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This lets the user specify a configuration file to load, disregarding
the builtin heuristics for locating it

Fixes #93 