### PR TITLE
fix: Create leases file if it does not exist

### DIFF
--- a/plugins/range/plugin.go
+++ b/plugins/range/plugin.go
@@ -151,7 +151,7 @@ func setupRange(v6 bool, args ...string) (handler.Handler6, handler.Handler4, er
 	if err != nil {
 		return Handler6, Handler4, fmt.Errorf("invalid duration: %v", args[3])
 	}
-	r, err := os.Open(filename)
+	r, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE, 0640)
 	defer func() {
 		if err := r.Close(); err != nil {
 			log.Warningf("Failed to close file %s: %v", filename, err)


### PR DESCRIPTION
If the leases.txt file was not present on the system, coredhcp would
fail to start --
```
level=info msg="DHCPv4: loading plugin `range`" prefix=plugins
level=warning msg="Failed to close file leases.txt: invalid argument" prefix="plugins/range"
level=fatal msg="cannot open lease file leases.txt: open leases.txt: no such file or directory" prefix=main
```

This changes the call to include the O_CREATE flag to create the
leases file if it does not already exist.

Signed-off-by: Brad Beam <brad.beam@b-rad.info>