### PR TITLE
feat: Add domainname and ntp plugins

### DIFF
--- a/cmds/coredhcp-generator/core-plugins.txt
+++ b/cmds/coredhcp-generator/core-plugins.txt
@@ -1,8 +1,10 @@
 github.com/coredhcp/coredhcp/plugins/dns
+github.com/coredhcp/coredhcp/plugins/domainname
 github.com/coredhcp/coredhcp/plugins/file
 github.com/coredhcp/coredhcp/plugins/leasetime
-github.com/coredhcp/coredhcp/plugins/netmask
 github.com/coredhcp/coredhcp/plugins/nbp
+github.com/coredhcp/coredhcp/plugins/netmask
+github.com/coredhcp/coredhcp/plugins/ntp
 github.com/coredhcp/coredhcp/plugins/prefix
 github.com/coredhcp/coredhcp/plugins/range
 github.com/coredhcp/coredhcp/plugins/router

--- a/cmds/coredhcp/main.go
+++ b/cmds/coredhcp/main.go
@@ -20,10 +20,12 @@ import (
 
 	"github.com/coredhcp/coredhcp/plugins"
 	pl_dns "github.com/coredhcp/coredhcp/plugins/dns"
+	pl_domainname "github.com/coredhcp/coredhcp/plugins/domainname"
 	pl_file "github.com/coredhcp/coredhcp/plugins/file"
 	pl_leasetime "github.com/coredhcp/coredhcp/plugins/leasetime"
 	pl_nbp "github.com/coredhcp/coredhcp/plugins/nbp"
 	pl_netmask "github.com/coredhcp/coredhcp/plugins/netmask"
+	pl_ntp "github.com/coredhcp/coredhcp/plugins/ntp"
 	pl_prefix "github.com/coredhcp/coredhcp/plugins/prefix"
 	pl_range "github.com/coredhcp/coredhcp/plugins/range"
 	pl_router "github.com/coredhcp/coredhcp/plugins/router"
@@ -59,11 +61,13 @@ func getLogLevels() []string {
 
 var desiredPlugins = []*plugins.Plugin{
 	&pl_dns.Plugin,
+	&pl_domainname.Plugin,
 	&pl_file.Plugin,
 	&pl_leasetime.Plugin,
 	&pl_nbp.Plugin,
 	&pl_netmask.Plugin,
 	&pl_prefix.Plugin,
+	&pl_ntp.Plugin,
 	&pl_range.Plugin,
 	&pl_router.Plugin,
 	&pl_serverid.Plugin,

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/cast v1.3.1
 	github.com/spf13/viper v1.7.0
+	github.com/stretchr/testify v1.6.1
 	github.com/u-root/u-root v6.0.0+incompatible // indirect
 	github.com/willf/bitset v1.1.10
 	github.com/x-cray/logrus-prefixed-formatter v0.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -214,6 +214,8 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -241,7 +243,6 @@ golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
 golang.org/x/exp v0.0.0-20190829153037-c13cbed26979/go.mod h1:86+5VVa7VpoJ4kLfm080zCjGlMRFzhUhsZKEZO7MGek=
-golang.org/x/exp v0.0.0-20191030013958-a1ab85dbe136 h1:A1gGSx58LAGVHUUsOf7IiR0u8Xb6W51gRwfDBhkdcaw=
 golang.org/x/exp v0.0.0-20191030013958-a1ab85dbe136/go.mod h1:JXzH8nQsPlswgeRAPE3MuO9GYsAcnJvJ4vnMwN/5qkY=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
@@ -255,7 +256,6 @@ golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
-golang.org/x/mod v0.1.0 h1:sfUMP1Gu8qASkorDVjnMuvgJzwFbTZSeXFiGBYAVdl4=
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -309,7 +309,6 @@ golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299 h1:DYfZAGf2WMFjMxbgTjaC+2HC7NkNAQs+6Q8b9WEB/F4=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
@@ -380,6 +379,8 @@ gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/plugins/domainname/plugin.go
+++ b/plugins/domainname/plugin.go
@@ -1,0 +1,50 @@
+package domainname
+
+import (
+	"errors"
+
+	"github.com/coredhcp/coredhcp/handler"
+	"github.com/coredhcp/coredhcp/logger"
+	"github.com/coredhcp/coredhcp/plugins"
+	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/insomniacslk/dhcp/dhcpv6"
+)
+
+var log = logger.GetLogger("plugins/domainname")
+
+var domainname string
+
+// Plugin wraps the DNS plugin information.
+var Plugin = plugins.Plugin{
+	Name:   "domainname",
+	Setup6: setup6,
+	Setup4: setup4,
+}
+
+func setup6(args ...string) (handler.Handler6, error) {
+	return nil, nil
+}
+
+func setup4(args ...string) (handler.Handler4, error) {
+	log.Println("loaded plugin for DHCPv4.")
+	if len(args) != 1 {
+		return nil, errors.New("need a single domain name")
+	}
+
+	domainname = args[0]
+	log.Infof("loaded %s domain name.", domainname)
+
+	return Handler4, nil
+}
+
+func Handler6(req, resp dhcpv6.DHCPv6) (dhcpv6.DHCPv6, bool) {
+	return nil, true
+}
+
+func Handler4(req, resp *dhcpv4.DHCPv4) (*dhcpv4.DHCPv4, bool) {
+	if req.IsOptionRequested(dhcpv4.OptionDomainName) {
+		resp.Options.Update(dhcpv4.OptDomainName(domainname))
+	}
+
+	return resp, false
+}

--- a/plugins/domainname/plugin_test.go
+++ b/plugins/domainname/plugin_test.go
@@ -1,0 +1,69 @@
+package domainname
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/coredhcp/coredhcp/logger"
+	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddDomainNameServer4(t *testing.T) {
+	// Disable logging for tests
+	logger.WithNoStdOutErr(log)
+
+	var mac = net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}
+	testCases := []struct {
+		desc          string
+		domainname    []string
+		expectedError bool
+	}{
+		{
+			desc:       "with domainname",
+			domainname: []string{"coredhcp.io"},
+		},
+		{
+			desc:          "without domainname",
+			domainname:    []string{},
+			expectedError: true,
+		},
+		{
+			desc:          "too many args",
+			domainname:    []string{"coredhcp.io", "coredhcp.io"},
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%q", tc.desc), func(t *testing.T) {
+			var err error
+
+			_, err = setup4(tc.domainname...)
+			if tc.expectedError {
+				assert.Error(t, err)
+				return
+			} else {
+				assert.NoError(t, err)
+			}
+
+			req, err := dhcpv4.NewDiscovery(mac)
+			assert.NoError(t, err)
+
+			stub, err := dhcpv4.NewReplyFromRequest(req)
+			assert.NoError(t, err)
+
+			resp, stop := Handler4(req, stub)
+			if resp == nil {
+				t.Fatal("plugin did not return a message")
+			}
+			if stop {
+				t.Error("plugin interrupted processing")
+			}
+
+			// Validate response
+			assert.Equal(t, tc.domainname[0], resp.DomainName())
+		})
+	}
+}

--- a/plugins/ntp/plugin.go
+++ b/plugins/ntp/plugin.go
@@ -1,0 +1,57 @@
+package ntp
+
+import (
+	"errors"
+	"net"
+
+	"github.com/coredhcp/coredhcp/handler"
+	"github.com/coredhcp/coredhcp/logger"
+	"github.com/coredhcp/coredhcp/plugins"
+	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/insomniacslk/dhcp/dhcpv6"
+)
+
+var log = logger.GetLogger("plugins/ntp")
+
+var ntpservers []net.IP
+
+// Plugin wraps the DNS plugin information.
+var Plugin = plugins.Plugin{
+	Name:   "ntp",
+	Setup6: setup6,
+	Setup4: setup4,
+}
+
+func setup6(args ...string) (handler.Handler6, error) {
+	return nil, nil
+}
+
+func setup4(args ...string) (handler.Handler4, error) {
+	log.Println("loaded plugin for DHCPv4.")
+	if len(args) < 1 {
+		return nil, errors.New("need at least one NTP server")
+	}
+
+	for _, arg := range args {
+		NTPServer := net.ParseIP(arg)
+		if NTPServer.To4() == nil {
+			return Handler4, errors.New("expected a NTP server address, got: " + arg)
+		}
+		ntpservers = append(ntpservers, NTPServer)
+	}
+	log.Infof("loaded %d ntp servers.", len(ntpservers))
+
+	return Handler4, nil
+}
+
+func Handler6(req, resp dhcpv6.DHCPv6) (dhcpv6.DHCPv6, bool) {
+	return nil, true
+}
+
+func Handler4(req, resp *dhcpv4.DHCPv4) (*dhcpv4.DHCPv4, bool) {
+	if req.IsOptionRequested(dhcpv4.OptionNTPServers) {
+		resp.Options.Update(dhcpv4.OptNTPServers(ntpservers...))
+	}
+
+	return resp, false
+}

--- a/plugins/ntp/plugin_test.go
+++ b/plugins/ntp/plugin_test.go
@@ -1,0 +1,69 @@
+package ntp
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/coredhcp/coredhcp/logger"
+	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddNTPServer4(t *testing.T) {
+	// Disable logging for tests
+	logger.WithNoStdOutErr(log)
+
+	var mac = net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}
+	testCases := []struct {
+		desc          string
+		ntpServers    []string
+		expectedError bool
+	}{
+		{
+			desc:       "with ntp servers",
+			ntpServers: []string{"10.10.10.10"},
+		},
+		{
+			desc:          "with hostname ntp servers",
+			ntpServers:    []string{"time.coredns.io"},
+			expectedError: true,
+		},
+		{
+			desc:          "without ntp servers",
+			ntpServers:    []string{},
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%q", tc.desc), func(t *testing.T) {
+			handler, err := setup4(tc.ntpServers...)
+			if tc.expectedError {
+				assert.Error(t, err)
+				return
+			} else {
+				assert.NoError(t, err)
+			}
+
+			mods := []dhcpv4.Modifier{dhcpv4.WithRequestedOptions(dhcpv4.OptionNTPServers)}
+
+			req, err := dhcpv4.NewDiscovery(mac, mods...)
+			assert.NoError(t, err)
+
+			stub, err := dhcpv4.NewReplyFromRequest(req)
+			assert.NoError(t, err)
+
+			resp, stop := handler(req, stub)
+			if resp == nil {
+				t.Fatal("plugin did not return a message")
+			}
+			if stop {
+				t.Error("plugin interrupted processing")
+			}
+
+			// Validate response
+			assert.Equal(t, resp.NTPServers()[0], net.ParseIP(tc.ntpServers[0]).To4())
+		})
+	}
+}


### PR DESCRIPTION
This introduces two additional plugins.

`domainname` allows you to specify a domain name for clients

`ntp` allows you to specify ntp servers for clients

Signed-off-by: Brad Beam <brad.beam@b-rad.info>