### PR TITLE
Switch to pflag

### DIFF
--- a/cmds/coredhcp-generator/coredhcp.go.template
+++ b/cmds/coredhcp-generator/coredhcp.go.template
@@ -4,12 +4,10 @@
 
 {{/* This file is the template source. The following comment obviously doesn't apply here */ -}}
 // This is a generated file, edits should be made in the corresponding source file
-// And this file regenerated using `coredhcp-generator -from core-plugins.txt`
-
+// And this file regenerated using `coredhcp-generator --from core-plugins.txt`
 package main
 
 import (
-	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -26,14 +24,15 @@ import (
 {{- end}}
 
 	"github.com/sirupsen/logrus"
+	flag "github.com/spf13/pflag"
 )
 
 var (
-	flagLogFile     = flag.String("logfile", "", "Name of the log file to append to. Default: stdout/stderr only")
-	flagLogNoStdout = flag.Bool("nostdout", false, "Disable logging to stdout/stderr")
-	flagLogLevel    = flag.String("loglevel", "info", fmt.Sprintf("Log level. One of %v", getLogLevels()))
-	flagConfig      = flag.String("conf", "", "Use this configuration file instead of the default location")
-	flagPlugins     = flag.Bool("plugins", false, "list plugins")
+	flagLogFile     = flag.StringP("logfile", "l", "", "Name of the log file to append to. Default: stdout/stderr only")
+	flagLogNoStdout = flag.BoolP("nostdout", "N", false, "Disable logging to stdout/stderr")
+	flagLogLevel    = flag.StringP("loglevel", "L", "info", fmt.Sprintf("Log level. One of %v", getLogLevels()))
+	flagConfig      = flag.StringP("conf", "c", "", "Use this configuration file instead of the default location")
+	flagPlugins     = flag.BoolP("plugins", "P", false, "list plugins")
 )
 
 var logLevels = map[string]func(*logrus.Logger){

--- a/cmds/coredhcp-generator/main.go
+++ b/cmds/coredhcp-generator/main.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"bufio"
-	"flag"
 	"fmt"
 	"html/template"
 	"io/ioutil"
@@ -15,6 +14,8 @@ import (
 	"path"
 	"sort"
 	"strings"
+
+	flag "github.com/spf13/pflag"
 )
 
 const (
@@ -23,9 +24,9 @@ const (
 )
 
 var (
-	flagTemplate = flag.String("template", defaultTemplateFile, "Template file name")
-	flagOutfile  = flag.String("outfile", "", "Output file path")
-	flagFromFile = flag.String("from", "", "Optional file name to get the plugin list from, one import path per line")
+	flagTemplate = flag.StringP("template", "t", defaultTemplateFile, "Template file name")
+	flagOutfile  = flag.StringP("outfile", "o", "", "Output file path")
+	flagFromFile = flag.StringP("from", "f", "", "Optional file name to get the plugin list from, one import path per line")
 )
 
 var funcMap = template.FuncMap{
@@ -114,6 +115,7 @@ func main() {
 		}
 		outfile = path.Join(tmpdir, "coredhcp.go")
 	}
+
 	log.Printf("Generating output file '%s' with %d plugin(s):", outfile, len(plugins))
 	idx := 1
 	for pl := range plugins {
@@ -139,5 +141,5 @@ func main() {
 		log.Fatalf("Template execution failed: %v", err)
 	}
 	log.Printf("Generated file '%s'. You can build it by running 'go build' in the output directory.", outfile)
-	fmt.Print(path.Dir(outfile))
+	fmt.Println(path.Dir(outfile))
 }

--- a/cmds/coredhcp/main.go
+++ b/cmds/coredhcp/main.go
@@ -3,12 +3,10 @@
 // LICENSE file in the root directory of this source tree.
 
 // This is a generated file, edits should be made in the corresponding source file
-// And this file regenerated using `coredhcp-generator -from core-plugins.txt`
-
+// And this file regenerated using `coredhcp-generator --from core-plugins.txt`
 package main
 
 import (
-	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -31,14 +29,15 @@ import (
 	pl_serverid "github.com/coredhcp/coredhcp/plugins/serverid"
 
 	"github.com/sirupsen/logrus"
+	flag "github.com/spf13/pflag"
 )
 
 var (
-	flagLogFile     = flag.String("logfile", "", "Name of the log file to append to. Default: stdout/stderr only")
-	flagLogNoStdout = flag.Bool("nostdout", false, "Disable logging to stdout/stderr")
-	flagLogLevel    = flag.String("loglevel", "info", fmt.Sprintf("Log level. One of %v", getLogLevels()))
-	flagConfig      = flag.String("conf", "", "Use this configuration file instead of the default location")
-	flagPlugins     = flag.Bool("plugins", false, "list plugins")
+	flagLogFile     = flag.StringP("logfile", "l", "", "Name of the log file to append to. Default: stdout/stderr only")
+	flagLogNoStdout = flag.BoolP("nostdout", "N", false, "Disable logging to stdout/stderr")
+	flagLogLevel    = flag.StringP("loglevel", "L", "info", fmt.Sprintf("Log level. One of %v", getLogLevels()))
+	flagConfig      = flag.StringP("conf", "c", "", "Use this configuration file instead of the default location")
+	flagPlugins     = flag.BoolP("plugins", "P", false, "list plugins")
 )
 
 var logLevels = map[string]func(*logrus.Logger){

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/cast v1.3.1
+	github.com/spf13/pflag v1.0.6-0.20201009195203-85dd5c8bc61c
 	github.com/spf13/viper v1.7.0
 	github.com/stretchr/testify v1.3.0
 	github.com/u-root/u-root v6.0.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -206,6 +206,10 @@ github.com/spf13/jwalterweatherman v1.0.0 h1:XHEdyB+EcvlqZamSM4ZOMGlc93t6AcsBEu9
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/pflag v1.0.6-0.20201009195203-85dd5c8bc61c h1:zqmyTlQyufRC65JnImJ6H1Sf7BDj8bG31EV919NVEQc=
+github.com/spf13/pflag v1.0.6-0.20201009195203-85dd5c8bc61c/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.7.0 h1:xVKxvI7ouOI5I+U9s2eeiUfMaWBVoXA3AWskkrqK0VM=
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
Switched `cmd/coredhcp-generator`, and as a consequence also
`cmd/coredhcp`, to `spf13/pflag` instead of the standard `flag`.
`pflag` gives GNU-style flags and supports args before flags, among many
other things.

Also copied `go.mod` and `go.sum` to the destination directory so it can
be built with go modules.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>