### PR TITLE
plugins/range: Add some locking and use the allocator interface

### DIFF
--- a/plugins/allocators/allocator.go
+++ b/plugins/allocators/allocator.go
@@ -8,6 +8,7 @@
 package allocators
 
 import (
+	"errors"
 	"fmt"
 	"net"
 )
@@ -42,3 +43,6 @@ type ErrDoubleFree struct {
 func (err *ErrDoubleFree) Error() string {
 	return fmt.Sprint("Attempted to free unallocated block at ", err.Loc.String())
 }
+
+// ErrNoAddrAvail is returned when we can't allocate an IP because there's no unallocated space left
+var ErrNoAddrAvail = errors.New("no address available to allocate")

--- a/plugins/allocators/bitmap/bitmap.go
+++ b/plugins/allocators/bitmap/bitmap.go
@@ -75,7 +75,7 @@ func (a *Allocator) Allocate(hint net.IPNet) (ret net.IPNet, err error) {
 	// Find a free prefix
 	next, ok := a.bitmap.NextClear(0)
 	if !ok {
-		err = errors.New("No prefix available")
+		err = allocators.ErrNoAddrAvail
 		return
 	}
 	a.bitmap.Set(next)

--- a/plugins/allocators/bitmap/bitmap_ipv4.go
+++ b/plugins/allocators/bitmap/bitmap_ipv4.go
@@ -1,0 +1,125 @@
+// Copyright 2018-present the CoreDHCP Authors. All rights reserved
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package bitmap
+
+// This allocator handles IPv4 assignments with a similar logic to the base bitmap, but a simpler
+// implementation due to the ability to just use uint32 for IPv4 addresses
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+
+	"github.com/coredhcp/coredhcp/plugins/allocators"
+	"github.com/willf/bitset"
+)
+
+var (
+	// ErrNoAddrAvail is returned when we can't allocate an IP
+	// because there's no unallocated space left
+	ErrNoAddrAvail = errors.New("No address available to allocate")
+
+	errNotInRange = errors.New("IP outside of allowed range")
+
+	errInvalidIP = errors.New("Invalid IP passed as input")
+)
+
+// IPv4Allocator allocates IPv4 addresses, tracking utilization with a bitmap
+type IPv4Allocator struct {
+	start uint32
+	end   uint32
+
+	bitmap *bitset.BitSet
+	l      sync.Mutex
+}
+
+func (a *IPv4Allocator) toIP(offset uint32) net.IP {
+	if offset > a.end-a.start {
+		return nil
+	}
+
+	r := make(net.IP, 4)
+	binary.BigEndian.PutUint32(r, a.start+offset)
+	return r
+}
+
+func (a *IPv4Allocator) toOffset(ip net.IP) (uint, error) {
+	if ip.To4() == nil {
+		return 0, errInvalidIP
+	}
+
+	intIP := binary.BigEndian.Uint32(ip.To4())
+	if intIP < a.start || intIP > a.end {
+		return 0, errNotInRange
+	}
+
+	return uint(intIP - a.start), nil
+}
+
+// Allocate reserves an IP for a client
+func (a *IPv4Allocator) Allocate(hint net.IPNet) (n net.IPNet, err error) {
+	n.Mask = net.CIDRMask(32, 32)
+
+	// This is just a hint, ignore any error with it
+	hintOffset, _ := a.toOffset(hint.IP)
+
+	a.l.Lock()
+	defer a.l.Unlock()
+
+	var next uint
+	// First try the exact match
+	if a.bitmap.Test(hintOffset) {
+		next = hintOffset
+	} else {
+		// Then any available address
+		avail, ok := a.bitmap.NextClear(0)
+		if !ok {
+			return n, ErrNoAddrAvail
+		}
+		next = avail
+	}
+
+	a.bitmap.Set(next)
+	n.IP = a.toIP(uint32(next))
+	return
+}
+
+// Free releases the given IP
+func (a *IPv4Allocator) Free(n net.IPNet) error {
+	offset, err := a.toOffset(n.IP)
+	if err != nil {
+		return errNotInRange
+	}
+
+	a.l.Lock()
+	defer a.l.Unlock()
+
+	if !a.bitmap.Test(uint(offset)) {
+		return &allocators.ErrDoubleFree{Loc: n}
+	}
+	a.bitmap.Clear(offset)
+	return nil
+}
+
+// NewIPv4Allocator creates a new allocator suitable for giving out IPv4 addresses
+func NewIPv4Allocator(start, end net.IP) (*IPv4Allocator, error) {
+	if start.To4() == nil || end.To4() == nil {
+		return nil, fmt.Errorf("Invalid IPv4s given to create the allocator: [%s,%s]", start, end)
+	}
+
+	alloc := IPv4Allocator{
+		start: binary.BigEndian.Uint32(start.To4()),
+		end:   binary.BigEndian.Uint32(end.To4()),
+	}
+
+	if alloc.start > alloc.end {
+		return nil, errors.New("No IPs in the given range to allocate")
+	}
+	alloc.bitmap = bitset.New(uint(alloc.end - alloc.start + 1))
+
+	return &alloc, nil
+}

--- a/plugins/allocators/bitmap/bitmap_ipv4_test.go
+++ b/plugins/allocators/bitmap/bitmap_ipv4_test.go
@@ -1,0 +1,54 @@
+// Copyright 2018-present the CoreDHCP Authors. All rights reserved
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package bitmap
+
+import (
+	"net"
+	"testing"
+)
+
+func getv4Allocator() *IPv4Allocator {
+	alloc, err := NewIPv4Allocator(net.IPv4(192, 0, 2, 0), net.IPv4(192, 0, 2, 255))
+	if err != nil {
+		panic(err)
+	}
+
+	return alloc
+}
+func Test4Alloc(t *testing.T) {
+	alloc := getv4Allocator()
+
+	net, err := alloc.Allocate(net.IPNet{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = alloc.Free(net)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = alloc.Free(net)
+	if err == nil {
+		t.Fatal("Expected DoubleFree error")
+	}
+}
+
+func Test4OutOfPool(t *testing.T) {
+	alloc := getv4Allocator()
+
+	hint := net.IPv4(198, 51, 100, 5)
+	res, err := alloc.Allocate(net.IPNet{IP: hint, Mask: net.CIDRMask(32, 32)})
+	if err != nil {
+		t.Fatalf("Failed to allocate with invalid hint: %v", err)
+	}
+	_, prefix, _ := net.ParseCIDR("192.0.2.0/24")
+	if !prefix.Contains(res.IP) {
+		t.Fatal("Obtained prefix outside of range: ", res)
+	}
+	if prefLen, totalLen := res.Mask.Size(); prefLen != 32 || totalLen != 32 {
+		t.Fatalf("Prefixes have wrong size %d/%d", prefLen, totalLen)
+	}
+}

--- a/plugins/range/plugin.go
+++ b/plugins/range/plugin.go
@@ -28,7 +28,6 @@ var log = logger.GetLogger("plugins/range")
 // Plugin wraps plugin registration information
 var Plugin = plugins.Plugin{
 	Name:   "range",
-	Setup6: setup6,
 	Setup4: setup4,
 }
 
@@ -114,12 +113,6 @@ func Handler4(req, resp *dhcpv4.DHCPv4) (*dhcpv4.DHCPv4, bool) {
 	resp.Options.Update(dhcpv4.OptIPAddressLeaseTime(LeaseTime))
 	log.Printf("found IP address %s for MAC %s", record.IP, req.ClientHWAddr.String())
 	return resp, false
-}
-
-func setup6(args ...string) (handler.Handler6, error) {
-	// TODO setup function for IPv6
-	log.Warning("not implemented for IPv6")
-	return Handler6, nil
 }
 
 func setup4(args ...string) (handler.Handler4, error) {

--- a/plugins/range/storage.go
+++ b/plugins/range/storage.go
@@ -1,0 +1,90 @@
+// Copyright 2018-present the CoreDHCP Authors. All rights reserved
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package rangeplugin
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"strings"
+	"time"
+)
+
+// loadRecords loads the DHCPv6/v4 Records global map with records stored on
+// the specified file. The records have to be one per line, a mac address and an
+// IP address.
+func loadRecords(r io.Reader) (map[string]*Record, error) {
+	sc := bufio.NewScanner(r)
+	records := make(map[string]*Record)
+	for sc.Scan() {
+		line := sc.Text()
+		if len(line) == 0 {
+			continue
+		}
+		tokens := strings.Fields(line)
+		if len(tokens) != 3 {
+			return nil, fmt.Errorf("malformed line, want 3 fields, got %d: %s", len(tokens), line)
+		}
+		hwaddr, err := net.ParseMAC(tokens[0])
+		if err != nil {
+			return nil, fmt.Errorf("malformed hardware address: %s", tokens[0])
+		}
+		ipaddr := net.ParseIP(tokens[1])
+		if ipaddr.To4() == nil {
+			return nil, fmt.Errorf("expected an IPv4 address, got: %v", ipaddr)
+		}
+		expires, err := time.Parse(time.RFC3339, tokens[2])
+		if err != nil {
+			return nil, fmt.Errorf("expected time of exipry in RFC3339 format, got: %v", tokens[2])
+		}
+		records[hwaddr.String()] = &Record{IP: ipaddr, expires: expires}
+	}
+	return records, nil
+}
+
+func loadRecordsFromFile(filename string) (map[string]*Record, error) {
+	reader, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE, 0640)
+	defer func() {
+		if err := reader.Close(); err != nil {
+			log.Warningf("Failed to close file %s: %v", filename, err)
+		}
+	}()
+	if err != nil {
+		return nil, fmt.Errorf("cannot open lease file %s: %w", filename, err)
+	}
+	return loadRecords(reader)
+}
+
+// saveIPAddress writes out a lease to storage
+func (p *PluginState) saveIPAddress(mac net.HardwareAddr, record *Record) error {
+	_, err := p.leasefile.WriteString(mac.String() + " " + record.IP.String() + " " + record.expires.Format(time.RFC3339) + "\n")
+	if err != nil {
+		return err
+	}
+	err = p.leasefile.Sync()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// registerBackingFile installs a file as the backing store for leases
+func (p *PluginState) registerBackingFile(filename string) error {
+	if p.leasefile != nil {
+		// This is TODO; swapping the file out is easy
+		// but maintaining consistency with the in-memory state isn't
+		return errors.New("cannot swap out a lease storage file while running")
+	}
+	// We never close this, but that's ok because plugins are never stopped/unregistered
+	newLeasefile, err := os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to open lease file %s: %w", filename, err)
+	}
+	p.leasefile = newLeasefile
+	return nil
+}

--- a/plugins/range/storage_test.go
+++ b/plugins/range/storage_test.go
@@ -1,0 +1,87 @@
+// Copyright 2018-present the CoreDHCP Authors. All rights reserved
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package rangeplugin
+
+import (
+	"io/ioutil"
+	"net"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var leasefile string = `02:00:00:00:00:00 10.0.0.0 2000-01-01T00:00:00Z
+02:00:00:00:00:01 10.0.0.1 2000-01-01T00:00:00Z
+02:00:00:00:00:02 10.0.0.2 2000-01-01T00:00:00Z
+02:00:00:00:00:03 10.0.0.3 2000-01-01T00:00:00Z
+02:00:00:00:00:04 10.0.0.4 2000-01-01T00:00:00Z
+02:00:00:00:00:05 10.0.0.5 2000-01-01T00:00:00Z
+`
+
+var expire = time.Date(2000, 01, 01, 00, 00, 00, 00, time.UTC)
+var records = []struct {
+	mac string
+	ip  *Record
+}{
+	{"02:00:00:00:00:00", &Record{net.IPv4(10, 0, 0, 0), expire}},
+	{"02:00:00:00:00:01", &Record{net.IPv4(10, 0, 0, 1), expire}},
+	{"02:00:00:00:00:02", &Record{net.IPv4(10, 0, 0, 2), expire}},
+	{"02:00:00:00:00:03", &Record{net.IPv4(10, 0, 0, 3), expire}},
+	{"02:00:00:00:00:04", &Record{net.IPv4(10, 0, 0, 4), expire}},
+	{"02:00:00:00:00:05", &Record{net.IPv4(10, 0, 0, 5), expire}},
+}
+
+func TestLoadRecords(t *testing.T) {
+	parsedRec, err := loadRecords(strings.NewReader(leasefile))
+	if err != nil {
+		t.Fatalf("Failed to load records from file: %v", err)
+	}
+
+	mapRec := make(map[string]*Record)
+	for _, rec := range records {
+		mapRec[rec.mac] = rec.ip
+	}
+
+	assert.Equal(t, mapRec, parsedRec, "Loaded records differ from what's in the file")
+}
+
+func TestWriteRecords(t *testing.T) {
+	tmpfile, err := ioutil.TempFile("", "coredhcptest")
+	if err != nil {
+		t.Skipf("Could not setup file-based test: %v", err)
+	}
+	defer os.Remove(tmpfile.Name())
+	defer tmpfile.Close()
+
+	pl := PluginState{}
+	if err := pl.registerBackingFile(tmpfile.Name()); err != nil {
+		t.Fatalf("Could not setup file")
+	}
+	defer pl.leasefile.Close()
+
+	for _, rec := range records {
+		hwaddr, err := net.ParseMAC(rec.mac)
+		if err != nil {
+			// bug in testdata
+			panic(err)
+		}
+		if err := pl.saveIPAddress(hwaddr, rec.ip); err != nil {
+			t.Errorf("Failed to save ip for %s: %v", hwaddr, err)
+		}
+	}
+
+	if _, err := tmpfile.Seek(0, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	written, err := ioutil.ReadAll(tmpfile)
+	if err != nil {
+		t.Fatalf("Could not read back temp file")
+	}
+	assert.Equal(t, leasefile, string(written), "Data written to the file doesn't match records")
+}


### PR DESCRIPTION
Mixed improvements to overhaul the plugin
 * Use the allocator interface to allocate IPs
 * Focus on correctness by wrapping a lock for now; we'll improve that
   with some more fine-grained concurrency later
 * move things related to file storage of leases to a separate source
   file and add some minimal sanity-check tests
 * Don't open and close the file descriptor on every single packet
