### PR TITLE
ci: Map paths in codecov to paths in the repo

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,4 @@
+# Map file paths during tests to the canonical path in the repo
+fixes:
+    # Removes the prefix we use during github actions
+    - "src/github.com/coredhcp/coredhcp/::"


### PR DESCRIPTION
Codecov uses the location of files on disk during coverage, which in our action has an additional prefix compared to the path in the repo, making some of the stats in codecov not work.
https://docs.codecov.io/docs/fixing-paths explains how to address that