### PR TITLE
ci: Build coredhcp-generator output with modules

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,16 +48,15 @@ jobs:
           # trick.
           echo "GOPATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
           echo "GOBIN=$GITHUB_WORKSPACE/bin" >> $GITHUB_ENV
-          echo "GO111MODULE=off" >> $GITHUB_ENV # until we solve this for coredhcp-generator
       - name: build coredhcp-generator
         run: |
           set -exu
           cd "${GITHUB_WORKSPACE}"/src/github.com/${{ github.repository }}/cmds/coredhcp-generator
-          GO111MODULE=on go build
+          go build
           builddir=$(./coredhcp-generator -f core-plugins.txt)
           cd "${builddir}"
           ls -l
-          go get -v ./...
+          go mod init "coredhcp"
           go build
           gofmt -w "${builddir}/coredhcp.go"
           diff -u "${builddir}/coredhcp.go" "${GITHUB_WORKSPACE}"/src/github.com/${{ github.repository }}/cmds/coredhcp/main.go


### PR DESCRIPTION
Viper doesn't support running from gopath at all anymore
(https://github.com/spf13/viper/blob/master/TROUBLESHOOTING.md#cannot-find-package)
causing the hcl import error we've seen in PRs.
We can actually just init a stub go module here, and let whichever of
our dependencies specify their own needs in their own go.mod files. This
ends up resolving to "latest" for all our dependencies, which is roughly
equivalent to not having modules at all