### PR TITLE
Created sleep plugin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,7 @@ jobs:
           cd "${builddir}"
           ls -l
           go mod init "coredhcp"
+          go mod edit -replace "github.com/coredhcp/coredhcp=${GITHUB_WORKSPACE}/src/github.com/${{ github.repository }}"
           go build
           gofmt -w "${builddir}/coredhcp.go"
           diff -u "${builddir}/coredhcp.go" "${GITHUB_WORKSPACE}"/src/github.com/${{ github.repository }}/cmds/coredhcp/main.go

--- a/cmds/coredhcp-generator/core-plugins.txt
+++ b/cmds/coredhcp-generator/core-plugins.txt
@@ -8,3 +8,4 @@ github.com/coredhcp/coredhcp/plugins/range
 github.com/coredhcp/coredhcp/plugins/router
 github.com/coredhcp/coredhcp/plugins/serverid
 github.com/coredhcp/coredhcp/plugins/searchdomains
+github.com/coredhcp/coredhcp/plugins/sleep

--- a/cmds/coredhcp/main.go
+++ b/cmds/coredhcp/main.go
@@ -27,6 +27,7 @@ import (
 	pl_router "github.com/coredhcp/coredhcp/plugins/router"
 	pl_searchdomains "github.com/coredhcp/coredhcp/plugins/searchdomains"
 	pl_serverid "github.com/coredhcp/coredhcp/plugins/serverid"
+	pl_sleep "github.com/coredhcp/coredhcp/plugins/sleep"
 
 	"github.com/sirupsen/logrus"
 	flag "github.com/spf13/pflag"
@@ -68,6 +69,7 @@ var desiredPlugins = []*plugins.Plugin{
 	&pl_router.Plugin,
 	&pl_searchdomains.Plugin,
 	&pl_serverid.Plugin,
+	&pl_sleep.Plugin,
 }
 
 func main() {

--- a/plugins/sleep/plugin.go
+++ b/plugins/sleep/plugin.go
@@ -1,0 +1,89 @@
+// Copyright 2018-present the CoreDHCP Authors. All rights reserved
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package sleep
+
+// This plugin introduces a delay in the DHCP response.
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/coredhcp/coredhcp/handler"
+	"github.com/coredhcp/coredhcp/logger"
+	"github.com/coredhcp/coredhcp/plugins"
+	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/insomniacslk/dhcp/dhcpv6"
+)
+
+var (
+	pluginName = "sleep"
+	log        = logger.GetLogger("plugins/" + pluginName)
+)
+
+// Example configuration of the `sleep` plugin:
+//
+// server4:
+//   plugins:
+//     - sleep 300ms
+//     - file: "leases4.txt"
+//
+// server6:
+//   plugins:
+//     - sleep 1s
+//     - file: "leases6.txt"
+//
+// For the duration format, see the documentation of `time.ParseDuration`,
+// https://golang.org/pkg/time/#ParseDuration .
+
+// Plugin contains the `sleep` plugin data.
+var Plugin = plugins.Plugin{
+	Name:   pluginName,
+	Setup6: setup6,
+	Setup4: setup4,
+}
+
+func setup6(args ...string) (handler.Handler6, error) {
+	if len(args) != 1 {
+		return nil, fmt.Errorf("want exactly one argument, got %d", len(args))
+	}
+	delay, err := time.ParseDuration(args[0])
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse duration: %w", err)
+	}
+	log.Printf("loaded plugin for DHCPv6.")
+	return makeSleepHandler6(delay), nil
+}
+
+func setup4(args ...string) (handler.Handler4, error) {
+	if len(args) != 1 {
+		return nil, fmt.Errorf("want exactly one argument, got %d", len(args))
+	}
+	delay, err := time.ParseDuration(args[0])
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse duration: %w", err)
+	}
+	log.Printf("loaded plugin for DHCPv4.")
+	return makeSleepHandler4(delay), nil
+}
+
+func makeSleepHandler6(delay time.Duration) handler.Handler6 {
+	return func(req, resp dhcpv6.DHCPv6) (dhcpv6.DHCPv6, bool) {
+		log.Printf("introducing delay of %s in response", delay)
+		// return the unmodified response, and instruct coredhcp to continue to
+		// the next plugin.
+		time.Sleep(delay)
+		return resp, false
+	}
+}
+
+func makeSleepHandler4(delay time.Duration) handler.Handler4 {
+	return func(req, resp *dhcpv4.DHCPv4) (*dhcpv4.DHCPv4, bool) {
+		log.Printf("introducing delay of %s in response", delay)
+		// return the unmodified response, and instruct coredhcp to continue to
+		// the next plugin.
+		time.Sleep(delay)
+		return resp, false
+	}
+}


### PR DESCRIPTION
The `sleep` plugin introduces a delay in the chain of response to a DHCP
transaction.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>