### PR TITLE
refresh records when leases file is updated

### DIFF
--- a/cmds/coredhcp/config.yml.example
+++ b/cmds/coredhcp/config.yml.example
@@ -73,8 +73,10 @@ server6:
         - server_id: LL 00:de:ad:be:ef:00
 
         # file serves leases defined in a static file, matching link-layer addresses to IPs
-        # - file: <file name>
+        # - file: <file name> [autorefresh]
         # The file format is one lease per line, "<hw address> <IPv6>"
+        # When the 'autorefresh' argument is given, the plugin will try to refresh
+        # the lease mapping during runtime whenever the lease file is updated.
         - file: "leases.txt"
 
         # dns adds information about available DNS resolvers to the responses

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/chappjc/logrus-prefix v0.0.0-20180227015900-3a1d64819adb
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/google/gopacket v1.1.19
 	github.com/hugelgupf/socketpair v0.0.0-20190730060125-05d35a94e714 // indirect
 	github.com/insomniacslk/dhcp v0.0.0-20210120172423-cc9239ac6294


### PR DESCRIPTION
The leases in my environment are fetched over HTTP from an API and are updated periodically. Since I don't want to restart CoreDHCP every time the leases change, this PR should make the file plugin automatically update the lease database when the file was changed. It does so in a best-effort: if it can't update the database it will show a warning but nothing will break.