### PR TITLE
plugin refactor and refresh on SIGHUP

### DIFF
--- a/cmds/coredhcp-generator/coredhcp.go.template
+++ b/cmds/coredhcp-generator/coredhcp.go.template
@@ -52,9 +52,9 @@ func getLogLevels() []string {
 	return levels
 }
 
-var desiredPlugins = []*plugins.Plugin{
+var desiredPlugins = []plugins.Plugin{
 {{- range $plugin := .}}
-	&{{importname $plugin}}.Plugin,
+	&{{importname $plugin}}.Plugin{},
 {{- end}}
 }
 
@@ -63,7 +63,7 @@ func main() {
 
 	if *flagPlugins {
 		for _, p := range desiredPlugins {
-			fmt.Println(p.Name)
+			fmt.Println(p.GetName())
 		}
 		os.Exit(0)
 	}
@@ -90,7 +90,7 @@ func main() {
 	// register plugins
 	for _, plugin := range desiredPlugins {
 		if err := plugins.RegisterPlugin(plugin); err != nil {
-			log.Fatalf("Failed to register plugin '%s': %v", plugin.Name, err)
+			log.Fatalf("Failed to register plugin '%s': %v", plugin.GetName(), err)
 		}
 	}
 

--- a/cmds/coredhcp/main.go
+++ b/cmds/coredhcp/main.go
@@ -59,19 +59,19 @@ func getLogLevels() []string {
 	return levels
 }
 
-var desiredPlugins = []*plugins.Plugin{
-	&pl_dns.Plugin,
-	&pl_file.Plugin,
-	&pl_leasetime.Plugin,
-	&pl_nbp.Plugin,
-	&pl_netmask.Plugin,
-	&pl_prefix.Plugin,
-	&pl_range.Plugin,
-	&pl_router.Plugin,
-	&pl_searchdomains.Plugin,
-	&pl_serverid.Plugin,
-	&pl_sleep.Plugin,
-	&pl_staticroute.Plugin,
+var desiredPlugins = []plugins.Plugin{
+	&pl_dns.Plugin{},
+	&pl_file.Plugin{},
+	&pl_leasetime.Plugin{},
+	&pl_nbp.Plugin{},
+	&pl_netmask.Plugin{},
+	&pl_prefix.Plugin{},
+	&pl_range.Plugin{},
+	&pl_router.Plugin{},
+	&pl_searchdomains.Plugin{},
+	&pl_serverid.Plugin{},
+	&pl_sleep.Plugin{},
+	&pl_staticroute.Plugin{},
 }
 
 func main() {
@@ -79,7 +79,7 @@ func main() {
 
 	if *flagPlugins {
 		for _, p := range desiredPlugins {
-			fmt.Println(p.Name)
+			fmt.Println(p.GetName())
 		}
 		os.Exit(0)
 	}
@@ -106,7 +106,7 @@ func main() {
 	// register plugins
 	for _, plugin := range desiredPlugins {
 		if err := plugins.RegisterPlugin(plugin); err != nil {
-			log.Fatalf("Failed to register plugin '%s': %v", plugin.Name, err)
+			log.Fatalf("Failed to register plugin '%s': %v", plugin.GetName(), err)
 		}
 	}
 

--- a/integ/server6_test.go
+++ b/integ/server6_test.go
@@ -47,7 +47,7 @@ var serverConfig = config.Config{
 // This function *must* be run in its own routine
 // For now this assumes ns are created outside.
 // TODO: dynamically create NS and interfaces directly in the test program
-func runServer(readyCh chan<- struct{}, nsName string, desiredPlugins []*plugins.Plugin) {
+func runServer(readyCh chan<- struct{}, nsName string, desiredPlugins []plugins.Plugin) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 	ns, err := netns.GetFromName(nsName)
@@ -60,7 +60,7 @@ func runServer(readyCh chan<- struct{}, nsName string, desiredPlugins []*plugins
 	// register plugins
 	for _, pl := range desiredPlugins {
 		if err := plugins.RegisterPlugin(pl); err != nil {
-			log.Panicf("Failed to register plugin `%s`: %v", pl.Name, err)
+			log.Panicf("Failed to register plugin `%s`: %v", pl.GetName(), err)
 		}
 	}
 	// start DHCP server
@@ -107,8 +107,8 @@ func TestDora(t *testing.T) {
 	readyCh := make(chan struct{}, 1)
 	go runServer(readyCh,
 		"coredhcp-direct-upper",
-		[]*plugins.Plugin{
-			&serverid.Plugin, &file.Plugin,
+		[]plugins.Plugin{
+			&serverid.Plugin{}, &file.Plugin{},
 		},
 	)
 	// wait for server to be ready before sending DHCP request

--- a/plugins/dns/plugin.go
+++ b/plugins/dns/plugin.go
@@ -10,26 +10,27 @@ import (
 
 	"github.com/coredhcp/coredhcp/handler"
 	"github.com/coredhcp/coredhcp/logger"
-	"github.com/coredhcp/coredhcp/plugins"
 	"github.com/insomniacslk/dhcp/dhcpv4"
 	"github.com/insomniacslk/dhcp/dhcpv6"
 )
 
-var log = logger.GetLogger("plugins/dns")
-
-// Plugin wraps the DNS plugin information.
-var Plugin = plugins.Plugin{
-	Name:   "dns",
-	Setup6: setup6,
-	Setup4: setup4,
-}
-
 var (
+	log         = logger.GetLogger("plugins/dns")
 	dnsServers6 []net.IP
 	dnsServers4 []net.IP
 )
 
-func setup6(args ...string) (handler.Handler6, error) {
+// Plugin implements the Plugin interface
+type Plugin struct {
+}
+
+// GetName returns the name of the plugin
+func (p *Plugin) GetName() string {
+	return "dns"
+}
+
+// Setup6 is the setup function to initialize the handler for DHCPv6
+func (p *Plugin) Setup6(args ...string) (handler.Handler6, error) {
 	if len(args) < 1 {
 		return nil, errors.New("need at least one DNS server")
 	}
@@ -44,7 +45,13 @@ func setup6(args ...string) (handler.Handler6, error) {
 	return Handler6, nil
 }
 
-func setup4(args ...string) (handler.Handler4, error) {
+// Refresh6 is called when the DHCPv6 is signaled to refresh
+func (p *Plugin) Refresh6() error {
+	return nil
+}
+
+// Setup4 is the setup function to initialize the handler for DHCPv4
+func (p *Plugin) Setup4(args ...string) (handler.Handler4, error) {
 	log.Printf("loaded plugin for DHCPv4.")
 	if len(args) < 1 {
 		return nil, errors.New("need at least one DNS server")
@@ -58,6 +65,11 @@ func setup4(args ...string) (handler.Handler4, error) {
 	}
 	log.Infof("loaded %d DNS servers.", len(dnsServers4))
 	return Handler4, nil
+}
+
+// Refresh4 is called when the DHCPv4 is signaled to refresh
+func (p *Plugin) Refresh4() error {
+	return nil
 }
 
 // Handler6 handles DHCPv6 packets for the dns plugin

--- a/plugins/dns/plugin_test.go
+++ b/plugins/dns/plugin_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/insomniacslk/dhcp/dhcpv4"
 	"github.com/insomniacslk/dhcp/dhcpv6"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAddServer6(t *testing.T) {
@@ -146,4 +147,9 @@ func TestNotRequested4(t *testing.T) {
 	if len(servers) != 0 {
 		t.Errorf("Found %d DNS servers when explicitly not requested", len(servers))
 	}
+}
+
+func TestGetName(t *testing.T) {
+	p := &Plugin{}
+	assert.Equal(t, "dns", p.GetName())
 }

--- a/plugins/example/plugin.go
+++ b/plugins/example/plugin.go
@@ -12,7 +12,6 @@ package example
 import (
 	"github.com/coredhcp/coredhcp/handler"
 	"github.com/coredhcp/coredhcp/logger"
-	"github.com/coredhcp/coredhcp/plugins"
 	"github.com/insomniacslk/dhcp/dhcpv4"
 	"github.com/insomniacslk/dhcp/dhcpv6"
 )
@@ -61,29 +60,48 @@ var log = logger.GetLogger("plugins/example")
 //   - server_id: LL aa:bb:cc:dd:ee:ff
 //   - file: "leases.txt"
 //
-var Plugin = plugins.Plugin{
-	Name:   "example",
-	Setup6: setup6,
-	Setup4: setup4,
+
+// Plugin implements the Plugin interface.
+type Plugin struct {
+	// additional parameters in this struct can be used to refer to during
+	// the life cycle of the plugin
 }
 
-// setup6 is the setup function to initialize the handler for DHCPv6
+// GetName returns the name of the plugin
+func (p *Plugin) GetName() string {
+	return "example"
+}
+
+// Setup6 is the setup function to initialize the handler for DHCPv6
 // traffic. This function implements the `plugin.SetupFunc6` interface.
 // This function returns a `handler.Handler6` function, and an error if any.
 // In this example we do very little in the setup function, and just return the
 // `exampleHandler6` function. Such function will be called for every DHCPv6
 // packet that the server receives. Remember that a handler may not be called
 // for each packet, if the handler chain is interrupted before reaching it.
-func setup6(args ...string) (handler.Handler6, error) {
+func (p *Plugin) Setup6(args ...string) (handler.Handler6, error) {
 	log.Printf("loaded plugin for DHCPv6.")
 	return exampleHandler6, nil
 }
 
-// setup4 behaves like setupExample6, but for DHCPv4 packets. It
+// Refresh6 is the function that is called when the DHCPv6 receives the SIGHUP
+// signal. It can be used to refresh configuration or storage from a backend
+func (p *Plugin) Refresh6() error {
+	// when the Refresh6 function is not required, just return nil
+	return nil
+}
+
+// Setup4 behaves like Setup6, but for DHCPv4 packets. It
 // implements the `plugin.SetupFunc4` interface.
-func setup4(args ...string) (handler.Handler4, error) {
+func (p *Plugin) Setup4(args ...string) (handler.Handler4, error) {
 	log.Printf("loaded plugin for DHCPv4.")
 	return exampleHandler4, nil
+}
+
+// Refresh4 is like Refresh6, but for the DHCPv4 server.
+func (p *Plugin) Refresh4() error {
+	// when the Refresh4 function is not required, just return nil
+	return nil
 }
 
 // exampleHandler6 handles DHCPv6 packets for the example plugin. It implements

--- a/plugins/leasetime/plugin.go
+++ b/plugins/leasetime/plugin.go
@@ -10,22 +10,22 @@ import (
 
 	"github.com/coredhcp/coredhcp/handler"
 	"github.com/coredhcp/coredhcp/logger"
-	"github.com/coredhcp/coredhcp/plugins"
 	"github.com/insomniacslk/dhcp/dhcpv4"
 )
-
-// Plugin wraps plugin registration information
-var Plugin = plugins.Plugin{
-	Name: "lease_time",
-	// currently not supported for DHCPv6
-	Setup6: nil,
-	Setup4: setup4,
-}
 
 var (
 	log         = logger.GetLogger("plugins/lease_time")
 	v4LeaseTime time.Duration
 )
+
+// Plugin wraps plugin registration information
+type Plugin struct {
+}
+
+// GetName returns the name of the plugin
+func (p *Plugin) GetName() string {
+	return "lease_time"
+}
 
 // Handler4 handles DHCPv4 packets for the lease_time plugin.
 func Handler4(req, resp *dhcpv4.DHCPv4) (*dhcpv4.DHCPv4, bool) {
@@ -39,7 +39,20 @@ func Handler4(req, resp *dhcpv4.DHCPv4) (*dhcpv4.DHCPv4, bool) {
 	return resp, false
 }
 
-func setup4(args ...string) (handler.Handler4, error) {
+// Setup6 is the setup function to initialize the handler for DHCPv6
+func (p *Plugin) Setup6(args ...string) (handler.Handler6, error) {
+	// currently not supported for DHCPv6
+	return nil, nil
+}
+
+// Refresh6 is called when the DHCPv6 is signaled to refresh
+func (p *Plugin) Refresh6() error {
+	// currently not implemented
+	return nil
+}
+
+// Setup4 is the setup function to initialize the handler for DHCPv4
+func (p *Plugin) Setup4(args ...string) (handler.Handler4, error) {
 	log.Print("loading `lease_time` plugin for DHCPv4")
 	if len(args) < 1 {
 		log.Error("No default lease time provided")
@@ -54,4 +67,10 @@ func setup4(args ...string) (handler.Handler4, error) {
 	v4LeaseTime = leaseTime
 
 	return Handler4, nil
+}
+
+// Refresh4 is called when the DHCPv4 is signaled to refresh
+func (p *Plugin) Refresh4() error {
+	// currently not implemented
+	return nil
 }

--- a/plugins/nbp/nbp.go
+++ b/plugins/nbp/nbp.go
@@ -35,24 +35,24 @@ import (
 
 	"github.com/coredhcp/coredhcp/handler"
 	"github.com/coredhcp/coredhcp/logger"
-	"github.com/coredhcp/coredhcp/plugins"
 	"github.com/insomniacslk/dhcp/dhcpv4"
 	"github.com/insomniacslk/dhcp/dhcpv6"
 )
 
-var log = logger.GetLogger("plugins/nbp")
-
-// Plugin wraps plugin registration information
-var Plugin = plugins.Plugin{
-	Name:   "nbp",
-	Setup6: setup6,
-	Setup4: setup4,
-}
-
 var (
+	log          = logger.GetLogger("plugins/nbp")
 	opt59, opt60 dhcpv6.Option
 	opt66, opt67 *dhcpv4.Option
 )
+
+// Plugin implements Plugin interface
+type Plugin struct {
+}
+
+// GetName returns the name of the plugin
+func (p *Plugin) GetName() string {
+	return "nbp"
+}
 
 func parseArgs(args ...string) (*url.URL, error) {
 	if len(args) != 1 {
@@ -61,7 +61,8 @@ func parseArgs(args ...string) (*url.URL, error) {
 	return url.Parse(args[0])
 }
 
-func setup6(args ...string) (handler.Handler6, error) {
+// Setup6 is the setup function to initialize the handler for DHCPv6
+func (p *Plugin) Setup6(args ...string) (handler.Handler6, error) {
 	u, err := parseArgs(args...)
 	if err != nil {
 		return nil, err
@@ -78,7 +79,14 @@ func setup6(args ...string) (handler.Handler6, error) {
 	return nbpHandler6, nil
 }
 
-func setup4(args ...string) (handler.Handler4, error) {
+// Refresh6 is called when the DHCPv6 is signaled to refresh
+func (p *Plugin) Refresh6() error {
+	// currently not implemented
+	return nil
+}
+
+// Setup4 is the setup function to initialize the handler for DHCPv4
+func (p *Plugin) Setup4(args ...string) (handler.Handler4, error) {
 	u, err := parseArgs(args...)
 	if err != nil {
 		return nil, err
@@ -97,6 +105,12 @@ func setup4(args ...string) (handler.Handler4, error) {
 	opt67 = &obfn
 	log.Printf("loaded NBP plugin for DHCPv4.")
 	return nbpHandler4, nil
+}
+
+// Refresh4 is called when the DHCPv4 is signaled to refresh
+func (p *Plugin) Refresh4() error {
+	// currently not implemented
+	return nil
 }
 
 func nbpHandler6(req, resp dhcpv6.DHCPv6) (dhcpv6.DHCPv6, bool) {

--- a/plugins/netmask/plugin.go
+++ b/plugins/netmask/plugin.go
@@ -11,23 +11,37 @@ import (
 
 	"github.com/coredhcp/coredhcp/handler"
 	"github.com/coredhcp/coredhcp/logger"
-	"github.com/coredhcp/coredhcp/plugins"
 	"github.com/insomniacslk/dhcp/dhcpv4"
 )
 
-var log = logger.GetLogger("plugins/netmask")
-
-// Plugin wraps plugin registration information
-var Plugin = plugins.Plugin{
-	Name:   "netmask",
-	Setup4: setup4,
-}
-
 var (
+	log     = logger.GetLogger("plugins/netmask")
 	netmask net.IPMask
 )
 
-func setup4(args ...string) (handler.Handler4, error) {
+// Plugin wraps plugin registration information
+type Plugin struct {
+}
+
+// GetName returns the name of the plugin
+func (p *Plugin) GetName() string {
+	return "netmask"
+}
+
+// Setup6 is the setup function to initialize the handler for DHCPv6
+func (p *Plugin) Setup6(args ...string) (handler.Handler6, error) {
+	// currently not implemented
+	return nil, nil
+}
+
+// Refresh6 is called when the DHCPv6 is signaled to refresh
+func (p *Plugin) Refresh6() error {
+	// currently not implemented
+	return nil
+}
+
+// Setup4 is the setup function to initialize the handler for DHCPv4
+func (p *Plugin) Setup4(args ...string) (handler.Handler4, error) {
 	log.Printf("loaded plugin for DHCPv4.")
 	if len(args) != 1 {
 		return nil, errors.New("need at least one netmask IP address")
@@ -46,6 +60,12 @@ func setup4(args ...string) (handler.Handler4, error) {
 	}
 	log.Printf("loaded client netmask")
 	return Handler4, nil
+}
+
+// Refresh4 is called when the DHCPv4 is signaled to refresh
+func (p *Plugin) Refresh4() error {
+	// currently not implemented
+	return nil
 }
 
 //Handler4 handles DHCPv4 packets for the netmask plugin

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -6,6 +6,9 @@ package plugins
 
 import (
 	"errors"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/coredhcp/coredhcp/config"
 	"github.com/coredhcp/coredhcp/handler"
@@ -14,36 +17,32 @@ import (
 
 var log = logger.GetLogger("plugins")
 
-// Plugin represents a plugin object.
-// Setup6 and Setup4 are the setup functions for DHCPv6 and DHCPv4 handlers
-// respectively. Both setup functions can be nil.
-type Plugin struct {
-	Name   string
-	Setup6 SetupFunc6
-	Setup4 SetupFunc4
+// Plugin is the interface all plugins need to implement.
+// Setup6 and Setup4 are the setup functions and Refresh6 and Refresh5 are the
+// refresh functions for DHCPv6 and DHCPv4 handlers respectively.
+type Plugin interface {
+	GetName() string
+	Setup6(args ...string) (handler.Handler6, error)
+	Refresh4() error
+	Setup4(args ...string) (handler.Handler4, error)
+	Refresh6() error
 }
 
 // RegisteredPlugins maps a plugin name to a Plugin instance.
 var RegisteredPlugins = make(map[string]*Plugin)
 
-// SetupFunc6 defines a plugin setup function for DHCPv6
-type SetupFunc6 func(args ...string) (handler.Handler6, error)
-
-// SetupFunc4 defines a plugin setup function for DHCPv6
-type SetupFunc4 func(args ...string) (handler.Handler4, error)
-
 // RegisterPlugin registers a plugin.
-func RegisterPlugin(plugin *Plugin) error {
+func RegisterPlugin(plugin Plugin) error {
 	if plugin == nil {
 		return errors.New("cannot register nil plugin")
 	}
-	log.Printf("Registering plugin '%s'", plugin.Name)
-	if _, ok := RegisteredPlugins[plugin.Name]; ok {
+	log.Printf("Registering plugin '%s'", plugin.GetName())
+	if _, ok := RegisteredPlugins[plugin.GetName()]; ok {
 		// TODO this highlights that asking the plugins to register themselves
 		// is not the right approach. Need to register them in the main program.
-		log.Panicf("Plugin '%s' is already registered", plugin.Name)
+		log.Panicf("Plugin '%s' is already registered", plugin.GetName())
 	}
-	RegisteredPlugins[plugin.Name] = plugin
+	RegisteredPlugins[plugin.GetName()] = &plugin
 	return nil
 }
 
@@ -57,6 +56,8 @@ func LoadPlugins(conf *config.Config) ([]handler.Handler4, []handler.Handler6, e
 	log.Print("Loading plugins...")
 	handlers4 := make([]handler.Handler4, 0)
 	handlers6 := make([]handler.Handler6, 0)
+	plugins4 := make([]*Plugin, 0)
+	plugins6 := make([]*Plugin, 0)
 
 	if conf.Server6 == nil && conf.Server4 == nil {
 		return nil, nil, errors.New("no configuration found for either DHCPv6 or DHCPv4")
@@ -71,17 +72,14 @@ func LoadPlugins(conf *config.Config) ([]handler.Handler4, []handler.Handler6, e
 		for _, pluginConf := range conf.Server6.Plugins {
 			if plugin, ok := RegisteredPlugins[pluginConf.Name]; ok {
 				log.Printf("DHCPv6: loading plugin `%s`", pluginConf.Name)
-				if plugin.Setup6 == nil {
-					log.Warningf("DHCPv6: plugin `%s` has no setup function for DHCPv6", pluginConf.Name)
-					continue
-				}
-				h6, err := plugin.Setup6(pluginConf.Args...)
+				h6, err := (*plugin).Setup6(pluginConf.Args...)
 				if err != nil {
 					return nil, nil, err
 				} else if h6 == nil {
 					return nil, nil, config.ConfigErrorFromString("no DHCPv6 handler for plugin %s", pluginConf.Name)
 				}
 				handlers6 = append(handlers6, h6)
+				plugins6 = append(plugins6, plugin)
 			} else {
 				return nil, nil, config.ConfigErrorFromString("DHCPv6: unknown plugin `%s`", pluginConf.Name)
 			}
@@ -93,22 +91,46 @@ func LoadPlugins(conf *config.Config) ([]handler.Handler4, []handler.Handler6, e
 		for _, pluginConf := range conf.Server4.Plugins {
 			if plugin, ok := RegisteredPlugins[pluginConf.Name]; ok {
 				log.Printf("DHCPv4: loading plugin `%s`", pluginConf.Name)
-				if plugin.Setup4 == nil {
-					log.Warningf("DHCPv4: plugin `%s` has no setup function for DHCPv4", pluginConf.Name)
-					continue
-				}
-				h4, err := plugin.Setup4(pluginConf.Args...)
+				h4, err := (*plugin).Setup4(pluginConf.Args...)
 				if err != nil {
 					return nil, nil, err
 				} else if h4 == nil {
 					return nil, nil, config.ConfigErrorFromString("no DHCPv4 handler for plugin %s", pluginConf.Name)
 				}
 				handlers4 = append(handlers4, h4)
+				plugins4 = append(plugins4, plugin)
 			} else {
 				return nil, nil, config.ConfigErrorFromString("DHCPv4: unknown plugin `%s`", pluginConf.Name)
 			}
 		}
 	}
+
+	// Setup signal handling so we can call the Refresh functions on all
+	// registered plugins once the SIGHUP signal is received
+	go func() {
+		signalCh := make(chan os.Signal, 1)
+		signal.Notify(signalCh, syscall.SIGHUP)
+
+		for range signalCh {
+			log.Println("Received SIGHUP")
+			if conf.Server6 != nil {
+				for _, plugin := range plugins6 {
+					log.Printf("DHCPv6: refreshing plugin `%s`", (*plugin).GetName())
+					if err := (*plugin).Refresh6(); err != nil {
+						log.Println(err.Error())
+					}
+				}
+			}
+			if conf.Server4 != nil {
+				for _, plugin := range plugins4 {
+					log.Printf("DHCPv4: refreshing plugin `%s`", (*plugin).GetName())
+					if err := (*plugin).Refresh4(); err != nil {
+						log.Println(err.Error())
+					}
+				}
+			}
+		}
+	}()
 
 	return handlers4, handlers6, nil
 }

--- a/plugins/prefix/plugin.go
+++ b/plugins/prefix/plugin.go
@@ -29,22 +29,25 @@ import (
 
 	"github.com/coredhcp/coredhcp/handler"
 	"github.com/coredhcp/coredhcp/logger"
-	"github.com/coredhcp/coredhcp/plugins"
 	"github.com/coredhcp/coredhcp/plugins/allocators"
 	"github.com/coredhcp/coredhcp/plugins/allocators/bitmap"
 )
 
 var log = logger.GetLogger("plugins/prefix")
 
-// Plugin registers the prefix. Prefix delegation only exists for DHCPv6
-var Plugin = plugins.Plugin{
-	Name:   "prefix",
-	Setup6: setupPrefix,
-}
-
 const leaseDuration = 3600 * time.Second
 
-func setupPrefix(args ...string) (handler.Handler6, error) {
+// Plugin implements the Plugin interface. Prefix delegation only exists for DHCPv6
+type Plugin struct {
+}
+
+// GetName returns the name of the plugin
+func (p *Plugin) GetName() string {
+	return "prefix"
+}
+
+// Setup6 is the setup function to initialize the handler for DHCPv6
+func (p *Plugin) Setup6(args ...string) (handler.Handler6, error) {
 	// - prefix: 2001:db8::/48 64
 	if len(args) < 2 {
 		return nil, errors.New("Need both a subnet and an allocation max size")
@@ -70,6 +73,24 @@ func setupPrefix(args ...string) (handler.Handler6, error) {
 		Records:   make(map[string][]lease),
 		allocator: alloc,
 	}).Handle, nil
+}
+
+// Refresh6 is called when the DHCPv6 is signaled to refresh
+func (p *Plugin) Refresh6() error {
+	// currently not implemented
+	return nil
+}
+
+// Setup4 is the setup function to initialize the handler for DHCPv4
+func (p *Plugin) Setup4(args ...string) (handler.Handler4, error) {
+	// currently not implemented
+	return nil, nil
+}
+
+// Refresh4 is called when the DHCPv4 is signaled to refresh
+func (p *Plugin) Refresh4() error {
+	// currently not implemented
+	return nil
 }
 
 type lease struct {

--- a/plugins/prefix/plugin_test.go
+++ b/plugins/prefix/plugin_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/insomniacslk/dhcp/dhcpv6"
 	dhcpIana "github.com/insomniacslk/dhcp/iana"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRoundTrip(t *testing.T) {
@@ -35,7 +36,9 @@ func TestRoundTrip(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	handler, err := setupPrefix("2001:db8::/48", "64")
+	p := &Plugin{}
+
+	handler, err := p.Setup6("2001:db8::/48", "64")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -90,4 +93,9 @@ func TestDup(t *testing.T) {
 	if !samePrefix(dupPrefix, prefix) {
 		t.Fatalf("dup doesn't work: got %v expected %v", dupPrefix, prefix)
 	}
+}
+
+func TestGetName(t *testing.T) {
+	p := &Plugin{}
+	assert.Equal(t, "prefix", p.GetName())
 }

--- a/plugins/router/plugin.go
+++ b/plugins/router/plugin.go
@@ -10,23 +10,35 @@ import (
 
 	"github.com/coredhcp/coredhcp/handler"
 	"github.com/coredhcp/coredhcp/logger"
-	"github.com/coredhcp/coredhcp/plugins"
 	"github.com/insomniacslk/dhcp/dhcpv4"
 )
 
-var log = logger.GetLogger("plugins/router")
-
-// Plugin wraps plugin registration information
-var Plugin = plugins.Plugin{
-	Name:   "router",
-	Setup4: setup4,
-}
-
 var (
+	log     = logger.GetLogger("plugins/router")
 	routers []net.IP
 )
 
-func setup4(args ...string) (handler.Handler4, error) {
+// Plugin implements the Plugin interface
+type Plugin struct {
+}
+
+// GetName returns the name of the plugin
+func (p *Plugin) GetName() string {
+	return "router"
+}
+
+// Setup6 is the setup function to initialize the handler for DHCPv6
+func (p *Plugin) Setup6(args ...string) (handler.Handler6, error) {
+	return nil, nil
+}
+
+// Refresh6 is called when the DHCPv6 is signaled to refresh
+func (p *Plugin) Refresh6() error {
+	return nil
+}
+
+// Setup4 is the setup function to initialize the handler for DHCPv4
+func (p *Plugin) Setup4(args ...string) (handler.Handler4, error) {
 	log.Printf("Loaded plugin for DHCPv4.")
 	if len(args) < 1 {
 		return nil, errors.New("need at least one router IP address")
@@ -40,6 +52,11 @@ func setup4(args ...string) (handler.Handler4, error) {
 	}
 	log.Infof("loaded %d router IP addresses.", len(routers))
 	return Handler4, nil
+}
+
+// Refresh4 is called when the DHCPv4 is signaled to refresh
+func (p *Plugin) Refresh4() error {
+	return nil
 }
 
 //Handler4 handles DHCPv4 packets for the router plugin

--- a/plugins/searchdomains/plugin_test.go
+++ b/plugins/searchdomains/plugin_test.go
@@ -17,11 +17,13 @@ import (
 func TestAddDomains6(t *testing.T) {
 	assert := assert.New(t)
 
+	p := &Plugin{}
+
 	// Search domains we will expect the DHCP server to assign
 	searchDomains := []string{"domain.a", "domain.b"}
 
 	// Init plugin
-	handler6, err := Plugin.Setup6(searchDomains...)
+	handler6, err := p.Setup6(searchDomains...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -57,6 +59,8 @@ func TestAddDomains6(t *testing.T) {
 func TestAddDomains4(t *testing.T) {
 	assert := assert.New(t)
 
+	p := &Plugin{}
+
 	// Search domains we will expect the DHCP server to assign
 	// NOTE: these domains should be different from the v6 test domains;
 	// this tests that we haven't accidentally set the v6 domains in the
@@ -64,7 +68,7 @@ func TestAddDomains4(t *testing.T) {
 	searchDomains := []string{"domain.b", "domain.c"}
 
 	// Init plugin
-	handler4, err := Plugin.Setup4(searchDomains...)
+	handler4, err := p.Setup4(searchDomains...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -92,5 +96,9 @@ func TestAddDomains4(t *testing.T) {
 
 	searchLabels := resp.DomainSearch().Labels
 	assert.Equal(searchDomains, searchLabels)
+}
 
+func TestGetName(t *testing.T) {
+	p := &Plugin{}
+	assert.Equal(t, "searchdomains", p.GetName())
 }

--- a/plugins/serverid/plugin.go
+++ b/plugins/serverid/plugin.go
@@ -11,26 +11,26 @@ import (
 
 	"github.com/coredhcp/coredhcp/handler"
 	"github.com/coredhcp/coredhcp/logger"
-	"github.com/coredhcp/coredhcp/plugins"
 	"github.com/insomniacslk/dhcp/dhcpv4"
 	"github.com/insomniacslk/dhcp/dhcpv6"
 	"github.com/insomniacslk/dhcp/iana"
 )
 
-var log = logger.GetLogger("plugins/server_id")
-
-// Plugin wraps plugin registration information
-var Plugin = plugins.Plugin{
-	Name:   "server_id",
-	Setup6: setup6,
-	Setup4: setup4,
-}
-
 // v6ServerID is the DUID of the v6 server
 var (
+	log        = logger.GetLogger("plugins/server_id")
 	v6ServerID *dhcpv6.Duid
 	v4ServerID net.IP
 )
+
+// Plugin implements the Plugin interface
+type Plugin struct {
+}
+
+// GetName returns the name of the plugin
+func (p *Plugin) GetName() string {
+	return "server_id"
+}
 
 // Handler6 handles DHCPv6 packets for the server_id plugin.
 func Handler6(req, resp dhcpv6.DHCPv6) (dhcpv6.DHCPv6, bool) {
@@ -95,7 +95,8 @@ func Handler4(req, resp *dhcpv4.DHCPv4) (*dhcpv4.DHCPv4, bool) {
 	return resp, false
 }
 
-func setup4(args ...string) (handler.Handler4, error) {
+// Setup4 is the setup function to initialize the handler for DHCPv4
+func (p *Plugin) Setup4(args ...string) (handler.Handler4, error) {
 	log.Printf("loading `server_id` plugin for DHCPv4 with args: %v", args)
 	if len(args) < 1 {
 		return nil, errors.New("need an argument")
@@ -111,7 +112,13 @@ func setup4(args ...string) (handler.Handler4, error) {
 	return Handler4, nil
 }
 
-func setup6(args ...string) (handler.Handler6, error) {
+// Refresh4 is called when the DHCPv4 is signaled to refresh
+func (p *Plugin) Refresh4() error {
+	return nil
+}
+
+// Setup6 is the setup function to initialize the handler for DHCPv6
+func (p *Plugin) Setup6(args ...string) (handler.Handler6, error) {
 	log.Printf("loading `server_id` plugin for DHCPv6 with args: %v", args)
 	if len(args) < 2 {
 		return nil, errors.New("need a DUID type and value")
@@ -154,4 +161,9 @@ func setup6(args ...string) (handler.Handler6, error) {
 	log.Printf("using %s %s", duidType, duidValue)
 
 	return Handler6, nil
+}
+
+// Refresh6 is called when the DHCPv6 is signaled to refresh
+func (p *Plugin) Refresh6() error {
+	return nil
 }

--- a/plugins/serverid/plugin_test.go
+++ b/plugins/serverid/plugin_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/insomniacslk/dhcp/dhcpv6"
+	"github.com/stretchr/testify/assert"
 )
 
 func makeTestDUID(uuid string) *dhcpv6.Duid {
@@ -123,4 +124,9 @@ func TestRejectInnerMessageServerID(t *testing.T) {
 	if !stop {
 		t.Error("server_id did not interrupt processing on a relayed solicit with a ServerID")
 	}
+}
+
+func TestGetName(t *testing.T) {
+	p := &Plugin{}
+	assert.Equal(t, "server_id", p.GetName())
 }

--- a/plugins/sleep/plugin.go
+++ b/plugins/sleep/plugin.go
@@ -12,15 +12,11 @@ import (
 
 	"github.com/coredhcp/coredhcp/handler"
 	"github.com/coredhcp/coredhcp/logger"
-	"github.com/coredhcp/coredhcp/plugins"
 	"github.com/insomniacslk/dhcp/dhcpv4"
 	"github.com/insomniacslk/dhcp/dhcpv6"
 )
 
-var (
-	pluginName = "sleep"
-	log        = logger.GetLogger("plugins/" + pluginName)
-)
+var log = logger.GetLogger("plugins/sleep")
 
 // Example configuration of the `sleep` plugin:
 //
@@ -37,14 +33,17 @@ var (
 // For the duration format, see the documentation of `time.ParseDuration`,
 // https://golang.org/pkg/time/#ParseDuration .
 
-// Plugin contains the `sleep` plugin data.
-var Plugin = plugins.Plugin{
-	Name:   pluginName,
-	Setup6: setup6,
-	Setup4: setup4,
+// Plugin implements the Plugin interface
+type Plugin struct {
 }
 
-func setup6(args ...string) (handler.Handler6, error) {
+// GetName returns the name of the plugin
+func (p *Plugin) GetName() string {
+	return "sleep"
+}
+
+// Setup6 is the setup function to initialize the handler for DHCPv6
+func (p *Plugin) Setup6(args ...string) (handler.Handler6, error) {
 	if len(args) != 1 {
 		return nil, fmt.Errorf("want exactly one argument, got %d", len(args))
 	}
@@ -56,7 +55,13 @@ func setup6(args ...string) (handler.Handler6, error) {
 	return makeSleepHandler6(delay), nil
 }
 
-func setup4(args ...string) (handler.Handler4, error) {
+// Refresh6 is called when the DHCPv6 is signaled to refresh
+func (p *Plugin) Refresh6() error {
+	return nil
+}
+
+// Setup4 is the setup function to initialize the handler for DHCPv4
+func (p *Plugin) Setup4(args ...string) (handler.Handler4, error) {
 	if len(args) != 1 {
 		return nil, fmt.Errorf("want exactly one argument, got %d", len(args))
 	}
@@ -66,6 +71,11 @@ func setup4(args ...string) (handler.Handler4, error) {
 	}
 	log.Printf("loaded plugin for DHCPv4.")
 	return makeSleepHandler4(delay), nil
+}
+
+// Refresh4 is called when the DHCPv4 is signaled to refresh
+func (p *Plugin) Refresh4() error {
+	return nil
 }
 
 func makeSleepHandler6(delay time.Duration) handler.Handler6 {

--- a/plugins/staticroute/plugin.go
+++ b/plugins/staticroute/plugin.go
@@ -11,21 +11,25 @@ import (
 
 	"github.com/coredhcp/coredhcp/handler"
 	"github.com/coredhcp/coredhcp/logger"
-	"github.com/coredhcp/coredhcp/plugins"
 	"github.com/insomniacslk/dhcp/dhcpv4"
 )
 
-var log = logger.GetLogger("plugins/staticroute")
+var (
+	log    = logger.GetLogger("plugins/staticroute")
+	routes dhcpv4.Routes
+)
 
-// Plugin wraps the information necessary to register a plugin.
-var Plugin = plugins.Plugin{
-	Name:   "staticroute",
-	Setup4: setup4,
+// Plugin implements the Plugin interface
+type Plugin struct {
 }
 
-var routes dhcpv4.Routes
+// GetName returns the name of the plugin
+func (p *Plugin) GetName() string {
+	return "staticroute"
+}
 
-func setup4(args ...string) (handler.Handler4, error) {
+// Setup4 is the setup function to initialize the handler for DHCPv4
+func (p *Plugin) Setup4(args ...string) (handler.Handler4, error) {
 	log.Printf("loaded plugin for DHCPv4.")
 	routes = make(dhcpv4.Routes, 0)
 
@@ -58,6 +62,21 @@ func setup4(args ...string) (handler.Handler4, error) {
 	log.Printf("loaded %d static routes.", len(routes))
 
 	return Handler4, nil
+}
+
+// Refresh4 is called when the DHCPv4 is signaled to refresh
+func (p *Plugin) Refresh4() error {
+	return nil
+}
+
+// Setup6 is the setup function to initialize the handler for DHCPv6
+func (p *Plugin) Setup6(args ...string) (handler.Handler6, error) {
+	return nil, nil
+}
+
+// Refresh6 is called when the DHCPv6 is signaled to refresh
+func (p *Plugin) Refresh6() error {
+	return nil
 }
 
 // Handler4 handles DHCPv4 packets for the static routes plugin

--- a/plugins/staticroute/plugin_test.go
+++ b/plugins/staticroute/plugin_test.go
@@ -13,33 +13,35 @@ import (
 func TestSetup4(t *testing.T) {
 	assert.Empty(t, routes)
 
+	p := &Plugin{}
+
 	var err error
 	// no args
-	_, err = setup4()
+	_, err = p.Setup4()
 	if assert.Error(t, err) {
 		assert.Equal(t, "need at least one static route", err.Error())
 	}
 
 	// invalid arg
-	_, err = setup4("foo")
+	_, err = p.Setup4("foo")
 	if assert.Error(t, err) {
 		assert.Equal(t, "expected a destination/gateway pair, got: foo", err.Error())
 	}
 
 	// invalid destination
-	_, err = setup4("foo,")
+	_, err = p.Setup4("foo,")
 	if assert.Error(t, err) {
 		assert.Equal(t, "expected a destination subnet, got: foo", err.Error())
 	}
 
 	// invalid gateway
-	_, err = setup4("10.0.0.0/8,foo")
+	_, err = p.Setup4("10.0.0.0/8,foo")
 	if assert.Error(t, err) {
 		assert.Equal(t, "expected a gateway address, got: foo", err.Error())
 	}
 
 	// valid route
-	_, err = setup4("10.0.0.0/8,192.168.1.1")
+	_, err = p.Setup4("10.0.0.0/8,192.168.1.1")
 	if assert.NoError(t, err) {
 		if assert.Equal(t, 1, len(routes)) {
 			assert.Equal(t, "10.0.0.0/8", routes[0].Dest.String())
@@ -48,7 +50,7 @@ func TestSetup4(t *testing.T) {
 	}
 
 	// multiple valid routes
-	_, err = setup4("10.0.0.0/8,192.168.1.1", "192.168.2.0/24,192.168.1.100")
+	_, err = p.Setup4("10.0.0.0/8,192.168.1.1", "192.168.2.0/24,192.168.1.100")
 	if assert.NoError(t, err) {
 		if assert.Equal(t, 2, len(routes)) {
 			assert.Equal(t, "10.0.0.0/8", routes[0].Dest.String())
@@ -57,4 +59,9 @@ func TestSetup4(t *testing.T) {
 			assert.Equal(t, "192.168.1.100", routes[1].Router.String())
 		}
 	}
+}
+
+func TestGetName(t *testing.T) {
+	p := &Plugin{}
+	assert.Equal(t, "staticroute", p.GetName())
 }


### PR DESCRIPTION
rewrote Plugin object to an interface that every plugin needs to implement

this allows for keeping arbitrary state inside the plugin that can be leveraged
in the refresh functions that are called on SIGHUP

**NOTE**: this PR is merely an idea, but I wanted to propose reimplementing the plugin structure.