### PR TITLE
fixed errors messages and added tests for netmask plugin

### DIFF
--- a/plugins/netmask/plugin.go
+++ b/plugins/netmask/plugin.go
@@ -34,15 +34,15 @@ func setup4(args ...string) (handler.Handler4, error) {
 	}
 	netmaskIP := net.ParseIP(args[0])
 	if netmaskIP.IsUnspecified() {
-		return nil, errors.New("netmask is not valid, got: " + args[1])
+		return nil, errors.New("netmask is not valid, got: " + args[0])
 	}
 	netmaskIP = netmaskIP.To4()
 	if netmaskIP == nil {
-		return nil, errors.New("expected an netmask address, got: " + args[1])
+		return nil, errors.New("expected an netmask address, got: " + args[0])
 	}
 	netmask = net.IPv4Mask(netmaskIP[0], netmaskIP[1], netmaskIP[2], netmaskIP[3])
 	if !checkValidNetmask(netmask) {
-		return nil, errors.New("netmask is not valid, got: " + args[1])
+		return nil, errors.New("netmask is not valid, got: " + args[0])
 	}
 	log.Printf("loaded client netmask")
 	return Handler4, nil

--- a/plugins/netmask/plugin_test.go
+++ b/plugins/netmask/plugin_test.go
@@ -1,0 +1,65 @@
+// Copyright 2018-present the CoreDHCP Authors. All rights reserved
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package netmask
+
+import (
+	"net"
+	"testing"
+
+	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckValidNetmask(t *testing.T) {
+	assert.True(t, checkValidNetmask(net.IPv4Mask(255, 255, 255, 0)))
+	assert.True(t, checkValidNetmask(net.IPv4Mask(255, 255, 0, 0)))
+	assert.True(t, checkValidNetmask(net.IPv4Mask(255, 0, 0, 0)))
+	assert.True(t, checkValidNetmask(net.IPv4Mask(0, 0, 0, 0)))
+
+	assert.False(t, checkValidNetmask(net.IPv4Mask(0, 255, 255, 255)))
+	assert.False(t, checkValidNetmask(net.IPv4Mask(0, 0, 255, 255)))
+	assert.False(t, checkValidNetmask(net.IPv4Mask(0, 0, 0, 255)))
+}
+
+func TestHandler4(t *testing.T) {
+	// set plugin netmask
+	netmask = net.IPv4Mask(255, 255, 255, 0)
+
+	// prepare DHCPv4 request
+	req := &dhcpv4.DHCPv4{}
+	resp := &dhcpv4.DHCPv4{
+		Options: dhcpv4.Options{},
+	}
+
+	// if we handle this DHCP request, the netmask should be one of the options
+	// of the result
+	result, stop := Handler4(req, resp)
+	assert.Same(t, result, resp)
+	assert.False(t, stop)
+	assert.EqualValues(t, netmask, resp.Options.Get(dhcpv4.OptionSubnetMask))
+}
+
+func TestSetup4(t *testing.T) {
+	// valid configuration
+	_, err := setup4("255.255.255.0")
+	assert.NoError(t, err)
+	assert.EqualValues(t, netmask, net.IPv4Mask(255, 255, 255, 0))
+
+	// no configuration
+	_, err = setup4()
+	assert.Error(t, err)
+
+	// unspecified netmask
+	_, err = setup4("0.0.0.0")
+	assert.Error(t, err)
+
+	// ipv6 prefix
+	_, err = setup4("ff02::/64")
+	assert.Error(t, err)
+
+	// invalid netmask
+	_, err = setup4("0.0.0.255")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
While I was testing my coredhcp setup, I misconfigured the netmask plugin which made CoreDHCP panic. I spotted the bug in formatting the error messages and decided to write some tests while at it.