### PR TITLE
ignore comment lines in file plugin

### DIFF
--- a/plugins/file/plugin.go
+++ b/plugins/file/plugin.go
@@ -85,6 +85,9 @@ func LoadDHCPv4Records(filename string) (map[string]net.IP, error) {
 		if len(line) == 0 {
 			continue
 		}
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
 		tokens := strings.Fields(line)
 		if len(tokens) != 2 {
 			return nil, fmt.Errorf("malformed line, want 2 fields, got %d: %s", len(tokens), line)
@@ -113,10 +116,12 @@ func LoadDHCPv6Records(filename string) (map[string]net.IP, error) {
 		return nil, err
 	}
 	records := make(map[string]net.IP)
-	// TODO ignore comments
 	for _, lineBytes := range bytes.Split(data, []byte{'\n'}) {
 		line := string(lineBytes)
 		if len(line) == 0 {
+			continue
+		}
+		if strings.HasPrefix(line, "#") {
 			continue
 		}
 		tokens := strings.Fields(line)

--- a/plugins/file/plugin_test.go
+++ b/plugins/file/plugin_test.go
@@ -27,14 +27,20 @@ func TestLoadDHCPv4Records(t *testing.T) {
 			os.Remove(tmp.Name())
 		}()
 
-		// fill temp file with valid lease lines
+		// fill temp file with valid lease lines and some comments
 		_, err = tmp.WriteString("00:11:22:33:44:55 192.0.2.100\n")
 		require.NoError(t, err)
 		_, err = tmp.WriteString("11:22:33:44:55:66 192.0.2.101\n")
 		require.NoError(t, err)
+		_, err = tmp.WriteString("# this is a comment\n")
+		require.NoError(t, err)
 
 		records, err := LoadDHCPv4Records(tmp.Name())
-		if assert.NoError(t, err) {
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		if assert.Equal(t, 2, len(records)) {
 			if assert.Contains(t, records, "00:11:22:33:44:55") {
 				assert.Equal(t, net.ParseIP("192.0.2.100"), records["00:11:22:33:44:55"])
 			}
@@ -119,14 +125,20 @@ func TestLoadDHCPv6Records(t *testing.T) {
 			os.Remove(tmp.Name())
 		}()
 
-		// fill temp file with valid lease lines
+		// fill temp file with valid lease lines and some comments
 		_, err = tmp.WriteString("00:11:22:33:44:55 2001:db8::10:1\n")
 		require.NoError(t, err)
 		_, err = tmp.WriteString("11:22:33:44:55:66 2001:db8::10:2\n")
 		require.NoError(t, err)
+		_, err = tmp.WriteString("# this is a comment\n")
+		require.NoError(t, err)
 
 		records, err := LoadDHCPv6Records(tmp.Name())
-		if assert.NoError(t, err) {
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		if assert.Equal(t, 2, len(records)) {
 			if assert.Contains(t, records, "00:11:22:33:44:55") {
 				assert.Equal(t, net.ParseIP("2001:db8::10:1"), records["00:11:22:33:44:55"])
 			}


### PR DESCRIPTION
This allows me to maintain my static lease files better and was marked as TODO in the code anyway