### PR TITLE
Lint version updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,7 @@ jobs:
           ls -l
           go mod init "coredhcp"
           go mod edit -replace "github.com/coredhcp/coredhcp=${GITHUB_WORKSPACE}/src/github.com/${{ github.repository }}"
+          go mod tidy
           go build
           gofmt -w "${builddir}/coredhcp.go"
           diff -u "${builddir}/coredhcp.go" "${GITHUB_WORKSPACE}"/src/github.com/${{ github.repository }}/cmds/coredhcp/main.go

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,15 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.14', '1.15']
+        go: ['1.14', '1.17', '1.18']
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # clone in the gopath
           path: src/github.com/${{ github.repository }}
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
-          stable: false
           go-version: ${{ matrix.go }}
       - name: setup environment
         run: |
@@ -32,15 +31,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.14', '1.15']
+        go: ['1.14', '1.17', '1.18']
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # clone in the gopath
           path: src/github.com/${{ github.repository }}
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
-          stable: false
           go-version: ${{ matrix.go }}
       - name: setup environment
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,11 +13,18 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+      - uses: actions/setup-go@v3
         with:
-          version: v1.29
+          go-version: 1.18
+      - uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+          version: v1.46.2
+
+          # Optional: working directory, useful for monorepos
+          # working-directory: somedir
 
           # Optional: golangci-lint command line arguments.
           # args: --issues-exit-code=0
@@ -25,13 +32,20 @@ jobs:
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true
 
-          # Optional: if set to true then the action will use pre-installed Go
-          # skip-go-installation: true
+          # Optional: if set to true then the all caching functionality will be complete disabled,
+          #           takes precedence over all other caching options.
+          # skip-cache: true
+
+          # Optional: if set to true then the action don't cache or restore ~/go/pkg.
+          # skip-pkg-cache: true
+
+          # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
+          # skip-build-cache: true 
   checklicenses:
     name: checklicenses
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: check license headers
         run: |
           set -exu

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,16 +7,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.14', '1.15']
+        go: ['1.14', '1.17', '1.18']
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # clone in the gopath
           path: src/github.com/${{ github.repository }}
           fetch-depth: 0
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
-          stable: false
           go-version: ${{ matrix.go }}
       - run: |
           # `env` doesn't allow for variable expansion, so we use the GITHUB_ENV
@@ -46,16 +45,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.14', '1.15']
+        go: ['1.14', '1.17', '1.18']
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # clone in the gopath
           path: src/github.com/${{ github.repository }}
           fetch-depth: 0
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
-          stable: false
           go-version: ${{ matrix.go }}
       - run: |
           # `env` doesn't allow for variable expansion, so we use the GITHUB_ENV


### PR DESCRIPTION
A general version bump for actions, including our lints and the base setup/checkout actions, and build with newer go versions too (while keeping the minimum supported version at 1.14 for now)