### PR TITLE
plugins: each plugin instance now has its own state

### DIFF
--- a/plugins/dns/plugin_test.go
+++ b/plugins/dns/plugin_test.go
@@ -25,13 +25,14 @@ func TestAddServer6(t *testing.T) {
 		t.Fatal(err)
 	}
 	stub.MessageType = dhcpv6.MessageTypeReply
-
-	dnsServers6 = []net.IP{
-		net.ParseIP("2001:db8::1"),
-		net.ParseIP("2001:db8::3"),
+	pState6 := &PluginState{
+		dnsServers: []net.IP{
+			net.ParseIP("2001:db8::1"),
+			net.ParseIP("2001:db8::3"),
+		},
 	}
 
-	resp, stop := Handler6(req, stub)
+	resp, stop := pState6.Handler6(req, stub)
 	if resp == nil {
 		t.Fatal("plugin did not return a message")
 	}
@@ -46,12 +47,12 @@ func TestAddServer6(t *testing.T) {
 	foundServers := resp.(*dhcpv6.Message).Options.DNS()
 	// XXX: is enforcing the order relevant here ?
 	for i, srv := range foundServers {
-		if !srv.Equal(dnsServers6[i]) {
-			t.Errorf("Found server %s, expected %s", srv, dnsServers6[i])
+		if !srv.Equal(pState6.dnsServers[i]) {
+			t.Errorf("Found server %s, expected %s", srv, pState6.dnsServers[i])
 		}
 	}
-	if len(foundServers) != len(dnsServers6) {
-		t.Errorf("Found %d servers, expected %d", len(foundServers), len(dnsServers6))
+	if len(foundServers) != len(pState6.dnsServers) {
+		t.Errorf("Found %d servers, expected %d", len(foundServers), len(pState6.dnsServers))
 	}
 }
 
@@ -68,12 +69,13 @@ func TestNotRequested6(t *testing.T) {
 		t.Fatal(err)
 	}
 	stub.MessageType = dhcpv6.MessageTypeReply
-
-	dnsServers6 = []net.IP{
-		net.ParseIP("2001:db8::1"),
+	pState6 := &PluginState{
+		dnsServers: []net.IP{
+			net.ParseIP("2001:db8::1"),
+		},
 	}
 
-	resp, stop := Handler6(req, stub)
+	resp, stop := pState6.Handler6(req, stub)
 	if resp == nil {
 		t.Fatal("plugin did not return a message")
 	}
@@ -96,13 +98,14 @@ func TestAddServer4(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	dnsServers4 = []net.IP{
-		net.ParseIP("192.0.2.1"),
-		net.ParseIP("192.0.2.3"),
+	pState4 := &PluginState{
+		dnsServers: []net.IP{
+			net.ParseIP("192.0.2.1"),
+			net.ParseIP("192.0.2.3"),
+		},
 	}
 
-	resp, stop := Handler4(req, stub)
+	resp, stop := pState4.Handler4(req, stub)
 	if resp == nil {
 		t.Fatal("plugin did not return a message")
 	}
@@ -111,12 +114,12 @@ func TestAddServer4(t *testing.T) {
 	}
 	servers := resp.DNS()
 	for i, srv := range servers {
-		if !srv.Equal(dnsServers4[i]) {
-			t.Errorf("Found server %s, expected %s", srv, dnsServers4[i])
+		if !srv.Equal(pState4.dnsServers[i]) {
+			t.Errorf("Found server %s, expected %s", srv, pState4.dnsServers[i])
 		}
 	}
-	if len(servers) != len(dnsServers4) {
-		t.Errorf("Found %d servers, expected %d", len(servers), len(dnsServers4))
+	if len(servers) != len(pState4.dnsServers) {
+		t.Errorf("Found %d servers, expected %d", len(servers), len(pState4.dnsServers))
 	}
 }
 
@@ -129,13 +132,14 @@ func TestNotRequested4(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	dnsServers4 = []net.IP{
-		net.ParseIP("192.0.2.1"),
+	pState4 := &PluginState{
+		dnsServers: []net.IP{
+			net.ParseIP("192.0.2.1"),
+		},
 	}
 	req.UpdateOption(dhcpv4.OptParameterRequestList(dhcpv4.OptionBroadcastAddress))
 
-	resp, stop := Handler4(req, stub)
+	resp, stop := pState4.Handler4(req, stub)
 	if resp == nil {
 		t.Fatal("plugin did not return a message")
 	}

--- a/plugins/file/plugin_test.go
+++ b/plugins/file/plugin_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -16,6 +17,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+var pTestState = &pluginState{
+	recLock:       sync.RWMutex{},
+	staticRecords: map[string]net.IP{},
+}
 
 func TestLoadDHCPv4Records(t *testing.T) {
 	t.Run("valid leases", func(t *testing.T) {
@@ -226,7 +232,7 @@ func TestHandler4(t *testing.T) {
 
 		// if we handle this DHCP request, nothing should change since the lease is
 		// unknown
-		result, stop := Handler4(req, resp)
+		result, stop := pTestState.Handler4(req, resp)
 		assert.Same(t, result, resp)
 		assert.False(t, stop)
 		assert.Nil(t, result.YourIPAddr)
@@ -244,19 +250,19 @@ func TestHandler4(t *testing.T) {
 
 		// add lease for the MAC in the lease map
 		clIPAddr := net.ParseIP("192.0.2.100")
-		StaticRecords = map[string]net.IP{
+		pTestState.staticRecords = map[string]net.IP{
 			mac: clIPAddr,
 		}
 
 		// if we handle this DHCP request, the YourIPAddr field should be set
 		// in the result
-		result, stop := Handler4(req, resp)
+		result, stop := pTestState.Handler4(req, resp)
 		assert.Same(t, result, resp)
 		assert.True(t, stop)
 		assert.Equal(t, clIPAddr, result.YourIPAddr)
 
 		// cleanup
-		StaticRecords = make(map[string]net.IP)
+		pTestState.staticRecords = make(map[string]net.IP)
 	})
 }
 
@@ -273,7 +279,7 @@ func TestHandler6(t *testing.T) {
 
 		// if we handle this DHCP request, nothing should change since the lease is
 		// unknown
-		result, stop := Handler6(req, resp)
+		result, stop := pTestState.Handler6(req, resp)
 		assert.False(t, stop)
 		assert.Equal(t, 0, len(result.GetOption(dhcpv6.OptionIANA)))
 	})
@@ -290,13 +296,13 @@ func TestHandler6(t *testing.T) {
 
 		// add lease for the MAC in the lease map
 		clIPAddr := net.ParseIP("2001:db8::10:1")
-		StaticRecords = map[string]net.IP{
+		pTestState.staticRecords = map[string]net.IP{
 			mac: clIPAddr,
 		}
 
 		// if we handle this DHCP request, there should be a specific IANA option
 		// set in the resulting response
-		result, stop := Handler6(req, resp)
+		result, stop := pTestState.Handler6(req, resp)
 		assert.False(t, stop)
 		if assert.Equal(t, 1, len(result.GetOption(dhcpv6.OptionIANA))) {
 			opt := result.GetOneOption(dhcpv6.OptionIANA)
@@ -304,24 +310,24 @@ func TestHandler6(t *testing.T) {
 		}
 
 		// cleanup
-		StaticRecords = make(map[string]net.IP)
+		pTestState.staticRecords = make(map[string]net.IP)
 	})
 }
 
 func TestSetupFile(t *testing.T) {
 	// too few arguments
-	_, _, err := setupFile(false)
+	_, _, err := pTestState.setupFile(false)
 	assert.Error(t, err)
 
 	// empty file name
-	_, _, err = setupFile(false, "")
+	_, _, err = pTestState.setupFile(false, "")
 	assert.Error(t, err)
 
 	// trigger error in LoadDHCPv*Records
-	_, _, err = setupFile(false, "/foo/bar")
+	_, _, err = pTestState.setupFile(false, "/foo/bar")
 	assert.Error(t, err)
 
-	_, _, err = setupFile(true, "/foo/bar")
+	_, _, err = pTestState.setupFile(true, "/foo/bar")
 	assert.Error(t, err)
 
 	// setup temp leases file
@@ -338,19 +344,19 @@ func TestSetupFile(t *testing.T) {
 		_, err = tmp.WriteString("11:22:33:44:55:66 2001:db8::10:2\n")
 		require.NoError(t, err)
 
-		assert.Equal(t, 0, len(StaticRecords))
+		assert.Equal(t, 0, len(pTestState.staticRecords))
 
 		// leases should show up in StaticRecords
-		_, _, err = setupFile(true, tmp.Name())
+		_, _, err = pTestState.setupFile(true, tmp.Name())
 		if assert.NoError(t, err) {
-			assert.Equal(t, 2, len(StaticRecords))
+			assert.Equal(t, 2, len(pTestState.staticRecords))
 		}
 	})
 
 	t.Run("autorefresh enabled", func(t *testing.T) {
-		_, _, err = setupFile(true, tmp.Name(), autoRefreshArg)
+		_, _, err = pTestState.setupFile(true, tmp.Name(), autoRefreshArg)
 		if assert.NoError(t, err) {
-			assert.Equal(t, 2, len(StaticRecords))
+			assert.Equal(t, 2, len(pTestState.staticRecords))
 		}
 		// we add more leases to the file
 		// this should trigger an event to refresh the leases database
@@ -361,9 +367,9 @@ func TestSetupFile(t *testing.T) {
 		time.Sleep(time.Millisecond * 100)
 		// an additional record should show up in the database
 		// but we should respect the locking first
-		recLock.RLock()
-		defer recLock.RUnlock()
+		pTestState.recLock.RLock()
+		defer pTestState.recLock.RUnlock()
 
-		assert.Equal(t, 3, len(StaticRecords))
+		assert.Equal(t, 3, len(pTestState.staticRecords))
 	})
 }

--- a/plugins/leasetime/plugin.go
+++ b/plugins/leasetime/plugin.go
@@ -22,19 +22,20 @@ var Plugin = plugins.Plugin{
 	Setup4: setup4,
 }
 
-var (
-	log         = logger.GetLogger("plugins/lease_time")
-	v4LeaseTime time.Duration
-)
+var log = logger.GetLogger("plugins/lease_time")
+
+type pluginState struct {
+	leaseTime time.Duration
+}
 
 // Handler4 handles DHCPv4 packets for the lease_time plugin.
-func Handler4(req, resp *dhcpv4.DHCPv4) (*dhcpv4.DHCPv4, bool) {
+func (p *pluginState) Handler4(req, resp *dhcpv4.DHCPv4) (*dhcpv4.DHCPv4, bool) {
 	if req.OpCode != dhcpv4.OpcodeBootRequest {
 		return resp, false
 	}
 	// Set lease time unless it has already been set
 	if !resp.Options.Has(dhcpv4.OptionIPAddressLeaseTime) {
-		resp.Options.Update(dhcpv4.OptIPAddressLeaseTime(v4LeaseTime))
+		resp.Options.Update(dhcpv4.OptIPAddressLeaseTime(p.leaseTime))
 	}
 	return resp, false
 }
@@ -51,7 +52,7 @@ func setup4(args ...string) (handler.Handler4, error) {
 		log.Errorf("invalid duration: %v", args[0])
 		return nil, errors.New("lease_time failed to initialize")
 	}
-	v4LeaseTime = leaseTime
+	pState := pluginState{leaseTime: leaseTime}
 
-	return Handler4, nil
+	return pState.Handler4, nil
 }

--- a/plugins/mtu/plugin.go
+++ b/plugins/mtu/plugin.go
@@ -7,9 +7,8 @@ package mtu
 import (
 	"errors"
 	"fmt"
-	"strconv"
-
 	"github.com/insomniacslk/dhcp/dhcpv4"
+	"strconv"
 
 	"github.com/coredhcp/coredhcp/handler"
 	"github.com/coredhcp/coredhcp/logger"
@@ -25,26 +24,27 @@ var Plugin = plugins.Plugin{
 	// No Setup6 since DHCPv6 does not have MTU-related options
 }
 
-var (
+type pluginState struct {
 	mtu int
-)
+}
 
 func setup4(args ...string) (handler.Handler4, error) {
 	if len(args) != 1 {
 		return nil, errors.New("need one mtu value")
 	}
 	var err error
-	if mtu, err = strconv.Atoi(args[0]); err != nil {
+	pState := &pluginState{}
+	if pState.mtu, err = strconv.Atoi(args[0]); err != nil {
 		return nil, fmt.Errorf("invalid mtu: %v", args[0])
 	}
-	log.Infof("loaded mtu %d.", mtu)
-	return Handler4, nil
+	log.Infof("loaded mtu %d.", pState.mtu)
+	return pState.Handler4, nil
 }
 
 // Handler4 handles DHCPv4 packets for the mtu plugin
-func Handler4(req, resp *dhcpv4.DHCPv4) (*dhcpv4.DHCPv4, bool) {
+func (p pluginState) Handler4(req, resp *dhcpv4.DHCPv4) (*dhcpv4.DHCPv4, bool) {
 	if req.IsOptionRequested(dhcpv4.OptionInterfaceMTU) {
-		resp.Options.Update(dhcpv4.Option{Code: dhcpv4.OptionInterfaceMTU, Value: dhcpv4.Uint16(mtu)})
+		resp.Options.Update(dhcpv4.Option{Code: dhcpv4.OptionInterfaceMTU, Value: dhcpv4.Uint16(p.mtu)})
 	}
 	return resp, false
 }

--- a/plugins/mtu/plugin_test.go
+++ b/plugins/mtu/plugin_test.go
@@ -21,9 +21,9 @@ func TestAddServer4(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mtu = 1500
+	pState := &pluginState{mtu: 1500}
 
-	resp, stop := Handler4(req, stub)
+	resp, stop := pState.Handler4(req, stub)
 	if resp == nil {
 		t.Fatal("plugin did not return a message")
 	}
@@ -35,8 +35,8 @@ func TestAddServer4(t *testing.T) {
 		t.Errorf("Failed to retrieve mtu from response")
 	}
 
-	if mtu != int(rMTU) {
-		t.Errorf("Found %d mtu, expected %d", rMTU, mtu)
+	if pState.mtu != int(rMTU) {
+		t.Errorf("Found %d mtu, expected %d", rMTU, pState.mtu)
 	}
 }
 
@@ -50,10 +50,10 @@ func TestNotRequested4(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mtu = 1500
+	pState := &pluginState{mtu: 1500}
 	req.UpdateOption(dhcpv4.OptParameterRequestList(dhcpv4.OptionBroadcastAddress))
 
-	resp, stop := Handler4(req, stub)
+	resp, stop := pState.Handler4(req, stub)
 	if resp == nil {
 		t.Fatal("plugin did not return a message")
 	}

--- a/plugins/netmask/plugin.go
+++ b/plugins/netmask/plugin.go
@@ -23,9 +23,9 @@ var Plugin = plugins.Plugin{
 	Setup4: setup4,
 }
 
-var (
+type pluginState struct {
 	netmask net.IPMask
-)
+}
 
 func setup4(args ...string) (handler.Handler4, error) {
 	log.Printf("loaded plugin for DHCPv4.")
@@ -40,17 +40,19 @@ func setup4(args ...string) (handler.Handler4, error) {
 	if netmaskIP == nil {
 		return nil, errors.New("expected an netmask address, got: " + args[0])
 	}
-	netmask = net.IPv4Mask(netmaskIP[0], netmaskIP[1], netmaskIP[2], netmaskIP[3])
-	if !checkValidNetmask(netmask) {
+	pState := &pluginState{
+		netmask: net.IPv4Mask(netmaskIP[0], netmaskIP[1], netmaskIP[2], netmaskIP[3]),
+	}
+	if !checkValidNetmask(pState.netmask) {
 		return nil, errors.New("netmask is not valid, got: " + args[0])
 	}
 	log.Printf("loaded client netmask")
-	return Handler4, nil
+	return pState.Handler4, nil
 }
 
 //Handler4 handles DHCPv4 packets for the netmask plugin
-func Handler4(req, resp *dhcpv4.DHCPv4) (*dhcpv4.DHCPv4, bool) {
-	resp.Options.Update(dhcpv4.OptSubnetMask(netmask))
+func (p pluginState) Handler4(req, resp *dhcpv4.DHCPv4) (*dhcpv4.DHCPv4, bool) {
+	resp.Options.Update(dhcpv4.OptSubnetMask(p.netmask))
 	return resp, false
 }
 

--- a/plugins/prefix/plugin.go
+++ b/plugins/prefix/plugin.go
@@ -66,7 +66,7 @@ func setupPrefix(args ...string) (handler.Handler6, error) {
 		return nil, fmt.Errorf("Could not initialize prefix allocator: %v", err)
 	}
 
-	return (&Handler{
+	return (&PluginState{
 		Records:   make(map[string][]lease),
 		allocator: alloc,
 	}).Handle, nil
@@ -77,8 +77,8 @@ type lease struct {
 	Expire time.Time
 }
 
-// Handler holds state of allocations for the plugin
-type Handler struct {
+// PluginState holds state of allocations for the plugin
+type PluginState struct {
 	// Mutex here is the simplest implementation fit for purpose.
 	// We can revisit for perf when we move lease management to separate plugins
 	sync.Mutex
@@ -103,7 +103,7 @@ func recordKey(d *dhcpv6.Duid) string {
 }
 
 // Handle processes DHCPv6 packets for the prefix plugin for a given allocator/leaseset
-func (h *Handler) Handle(req, resp dhcpv6.DHCPv6) (dhcpv6.DHCPv6, bool) {
+func (h *PluginState) Handle(req, resp dhcpv6.DHCPv6) (dhcpv6.DHCPv6, bool) {
 	msg, err := req.GetInnerMessage()
 	if err != nil {
 		log.Error(err)

--- a/plugins/serverid/plugin.go
+++ b/plugins/serverid/plugin.go
@@ -26,15 +26,18 @@ var Plugin = plugins.Plugin{
 	Setup4: setup4,
 }
 
-// v6ServerID is the DUID of the v6 server
-var (
+type pluginStateV6 struct {
+	// v6ServerID is the DUID of the v6 server
 	v6ServerID *dhcpv6.Duid
+}
+
+type pluginStateV4 struct {
 	v4ServerID net.IP
-)
+}
 
 // Handler6 handles DHCPv6 packets for the server_id plugin.
-func Handler6(req, resp dhcpv6.DHCPv6) (dhcpv6.DHCPv6, bool) {
-	if v6ServerID == nil {
+func (p pluginStateV6) Handler6(req, resp dhcpv6.DHCPv6) (dhcpv6.DHCPv6, bool) {
+	if p.v6ServerID == nil {
 		log.Fatal("BUG: Plugin is running uninitialized!")
 		return nil, true
 	}
@@ -56,8 +59,8 @@ func Handler6(req, resp dhcpv6.DHCPv6) (dhcpv6.DHCPv6, bool) {
 		}
 
 		// Approximately all others MUST be discarded if the ServerID doesn't match
-		if !sid.Equal(*v6ServerID) {
-			log.Infof("requested server ID does not match this server's ID. Got %v, want %v", sid, *v6ServerID)
+		if !sid.Equal(*p.v6ServerID) {
+			log.Infof("requested server ID does not match this server's ID. Got %v, want %v", sid, *p.v6ServerID)
 			return nil, true
 		}
 	} else if msg.MessageType == dhcpv6.MessageTypeRequest ||
@@ -68,13 +71,13 @@ func Handler6(req, resp dhcpv6.DHCPv6) (dhcpv6.DHCPv6, bool) {
 		// These message types MUST be discarded if they *don't* contain a ServerID option
 		return nil, true
 	}
-	dhcpv6.WithServerID(*v6ServerID)(resp)
+	dhcpv6.WithServerID(*p.v6ServerID)(resp)
 	return resp, false
 }
 
 // Handler4 handles DHCPv4 packets for the server_id plugin.
-func Handler4(req, resp *dhcpv4.DHCPv4) (*dhcpv4.DHCPv4, bool) {
-	if v4ServerID == nil {
+func (p pluginStateV4) Handler4(req, resp *dhcpv4.DHCPv4) (*dhcpv4.DHCPv4, bool) {
+	if p.v4ServerID == nil {
 		log.Fatal("BUG: Plugin is running uninitialized!")
 		return nil, true
 	}
@@ -84,14 +87,14 @@ func Handler4(req, resp *dhcpv4.DHCPv4) (*dhcpv4.DHCPv4, bool) {
 	}
 	if req.ServerIPAddr != nil &&
 		!req.ServerIPAddr.Equal(net.IPv4zero) &&
-		!req.ServerIPAddr.Equal(v4ServerID) {
+		!req.ServerIPAddr.Equal(p.v4ServerID) {
 		// This request is not for us, drop it.
-		log.Infof("requested server ID does not match this server's ID. Got %v, want %v", req.ServerIPAddr, v4ServerID)
+		log.Infof("requested server ID does not match this server's ID. Got %v, want %v", req.ServerIPAddr, p.v4ServerID)
 		return nil, true
 	}
 	resp.ServerIPAddr = make(net.IP, net.IPv4len)
-	copy(resp.ServerIPAddr[:], v4ServerID)
-	resp.UpdateOption(dhcpv4.OptServerIdentifier(v4ServerID))
+	copy(resp.ServerIPAddr[:], p.v4ServerID)
+	resp.UpdateOption(dhcpv4.OptServerIdentifier(p.v4ServerID))
 	return resp, false
 }
 
@@ -107,8 +110,7 @@ func setup4(args ...string) (handler.Handler4, error) {
 	if serverID.To4() == nil {
 		return nil, errors.New("not a valid IPv4 address")
 	}
-	v4ServerID = serverID.To4()
-	return Handler4, nil
+	return (&pluginStateV4{v4ServerID: serverID.To4()}).Handler4, nil
 }
 
 func setup6(args ...string) (handler.Handler6, error) {
@@ -129,6 +131,7 @@ func setup6(args ...string) (handler.Handler6, error) {
 	if err != nil {
 		return nil, err
 	}
+	var v6ServerID *dhcpv6.Duid
 	switch duidType {
 	case "ll", "duid-ll", "duid_ll":
 		v6ServerID = &dhcpv6.Duid{
@@ -152,6 +155,5 @@ func setup6(args ...string) (handler.Handler6, error) {
 		return nil, errors.New("Opaque DUID type not supported yet")
 	}
 	log.Printf("using %s %s", duidType, duidValue)
-
-	return Handler6, nil
+	return (&pluginStateV6{v6ServerID: v6ServerID}).Handler6, nil
 }

--- a/plugins/serverid/plugin_test.go
+++ b/plugins/serverid/plugin_test.go
@@ -23,7 +23,7 @@ func TestRejectBadServerIDV6(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	v6ServerID = makeTestDUID("0000000000000000")
+	pState := pluginStateV6{v6ServerID: makeTestDUID("0000000000000000")}
 
 	req.MessageType = dhcpv6.MessageTypeRenew
 	dhcpv6.WithClientID(*makeTestDUID("1000000000000000"))(req)
@@ -34,7 +34,7 @@ func TestRejectBadServerIDV6(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resp, stop := Handler6(req, stub)
+	resp, stop := pState.Handler6(req, stub)
 	if resp != nil {
 		t.Error("server_id is sending a response message to a request with mismatched ServerID")
 	}
@@ -48,7 +48,7 @@ func TestRejectUnexpectedServerIDV6(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	v6ServerID = makeTestDUID("0000000000000000")
+	pState := pluginStateV6{v6ServerID: makeTestDUID("0000000000000000")}
 
 	req.MessageType = dhcpv6.MessageTypeSolicit
 	dhcpv6.WithClientID(*makeTestDUID("1000000000000000"))(req)
@@ -59,7 +59,7 @@ func TestRejectUnexpectedServerIDV6(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resp, stop := Handler6(req, stub)
+	resp, stop := pState.Handler6(req, stub)
 	if resp != nil {
 		t.Error("server_id is sending a response message to a solicit with a ServerID")
 	}
@@ -73,7 +73,7 @@ func TestAddServerIDV6(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	v6ServerID = makeTestDUID("0000000000000000")
+	pState := pluginStateV6{v6ServerID: makeTestDUID("0000000000000000")}
 
 	req.MessageType = dhcpv6.MessageTypeRebind
 	dhcpv6.WithClientID(*makeTestDUID("1000000000000000"))(req)
@@ -83,15 +83,15 @@ func TestAddServerIDV6(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resp, _ := Handler6(req, stub)
+	resp, _ := pState.Handler6(req, stub)
 	if resp == nil {
 		t.Fatal("plugin did not return an answer")
 	}
 
 	if opt := resp.(*dhcpv6.Message).Options.ServerID(); opt == nil {
 		t.Fatal("plugin did not add a ServerID option")
-	} else if !opt.Equal(*v6ServerID) {
-		t.Fatalf("Got unexpected DUID: expected %v, got %v", v6ServerID, opt)
+	} else if !opt.Equal(*pState.v6ServerID) {
+		t.Fatalf("Got unexpected DUID: expected %v, got %v", pState.v6ServerID, opt)
 	}
 }
 
@@ -100,7 +100,7 @@ func TestRejectInnerMessageServerID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	v6ServerID = makeTestDUID("0000000000000000")
+	pState := pluginStateV6{v6ServerID: makeTestDUID("0000000000000000")}
 
 	req.MessageType = dhcpv6.MessageTypeSolicit
 	dhcpv6.WithClientID(*makeTestDUID("1000000000000000"))(req)
@@ -116,7 +116,7 @@ func TestRejectInnerMessageServerID(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resp, stop := Handler6(relayedRequest, stub)
+	resp, stop := pState.Handler6(relayedRequest, stub)
 	if resp != nil {
 		t.Error("server_id is sending a response message to a relayed solicit with a ServerID")
 	}

--- a/plugins/staticroute/plugin.go
+++ b/plugins/staticroute/plugin.go
@@ -23,11 +23,13 @@ var Plugin = plugins.Plugin{
 	Setup4: setup4,
 }
 
-var routes dhcpv4.Routes
+type pluginState struct {
+	routes dhcpv4.Routes
+}
 
 func setup4(args ...string) (handler.Handler4, error) {
 	log.Printf("loaded plugin for DHCPv4.")
-	routes = make(dhcpv4.Routes, 0)
+	pState := &pluginState{routes: []*dhcpv4.Route{}}
 
 	if len(args) < 1 {
 		return nil, errors.New("need at least one static route")
@@ -37,35 +39,35 @@ func setup4(args ...string) (handler.Handler4, error) {
 	for _, arg := range args {
 		fields := strings.Split(arg, ",")
 		if len(fields) != 2 {
-			return Handler4, errors.New("expected a destination/gateway pair, got: " + arg)
+			return pState.Handler4, errors.New("expected a destination/gateway pair, got: " + arg)
 		}
 
 		route := &dhcpv4.Route{}
 		_, route.Dest, err = net.ParseCIDR(fields[0])
 		if err != nil {
-			return Handler4, errors.New("expected a destination subnet, got: " + fields[0])
+			return pState.Handler4, errors.New("expected a destination subnet, got: " + fields[0])
 		}
 
 		route.Router = net.ParseIP(fields[1])
 		if route.Router == nil {
-			return Handler4, errors.New("expected a gateway address, got: " + fields[1])
+			return pState.Handler4, errors.New("expected a gateway address, got: " + fields[1])
 		}
 
-		routes = append(routes, route)
+		pState.routes = append(pState.routes, route)
 		log.Debugf("adding static route %s", route)
 	}
 
-	log.Printf("loaded %d static routes.", len(routes))
+	log.Printf("loaded %d static routes.", len(pState.routes))
 
-	return Handler4, nil
+	return pState.Handler4, nil
 }
 
 // Handler4 handles DHCPv4 packets for the static routes plugin
-func Handler4(req, resp *dhcpv4.DHCPv4) (*dhcpv4.DHCPv4, bool) {
-	if len(routes) > 0 {
+func (p pluginState) Handler4(req, resp *dhcpv4.DHCPv4) (*dhcpv4.DHCPv4, bool) {
+	if len(p.routes) > 0 {
 		resp.Options.Update(dhcpv4.Option{
 			Code:  dhcpv4.OptionCode(dhcpv4.OptionClasslessStaticRoute),
-			Value: routes,
+			Value: p.routes,
 		})
 	}
 

--- a/plugins/staticroute/plugin_test.go
+++ b/plugins/staticroute/plugin_test.go
@@ -5,17 +5,15 @@
 package staticroute
 
 import (
+	"github.com/insomniacslk/dhcp/dhcpv4"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestSetup4(t *testing.T) {
-	assert.Empty(t, routes)
-
-	var err error
 	// no args
-	_, err = setup4()
+	_, err := setup4()
 	if assert.Error(t, err) {
 		assert.Equal(t, "need at least one static route", err.Error())
 	}
@@ -38,8 +36,22 @@ func TestSetup4(t *testing.T) {
 		assert.Equal(t, "expected a gateway address, got: foo", err.Error())
 	}
 
+	// prepare DHCPv4 request
+	req := &dhcpv4.DHCPv4{}
+	resp := &dhcpv4.DHCPv4{
+		Options: dhcpv4.Options{},
+	}
+
 	// valid route
-	_, err = setup4("10.0.0.0/8,192.168.1.1")
+	handler, err := setup4("10.0.0.0/8,192.168.1.1")
+	result, stop := handler(req, resp)
+	assert.Same(t, result, resp)
+	assert.False(t, stop)
+	table := result.Options.Get(dhcpv4.OptionStaticRoutingTable)
+	routes := dhcpv4.Routes{}
+	if err := routes.FromBytes(table); err != nil {
+		t.Errorf("FromBytes(%v) Unexpected error state: %v", table, err)
+	}
 	if assert.NoError(t, err) {
 		if assert.Equal(t, 1, len(routes)) {
 			assert.Equal(t, "10.0.0.0/8", routes[0].Dest.String())
@@ -47,8 +59,19 @@ func TestSetup4(t *testing.T) {
 		}
 	}
 
+	//Clean options
+	resp.Options = dhcpv4.Options{}
+
 	// multiple valid routes
-	_, err = setup4("10.0.0.0/8,192.168.1.1", "192.168.2.0/24,192.168.1.100")
+	handler, err = setup4("10.0.0.0/8,192.168.1.1", "192.168.2.0/24,192.168.1.100")
+	result, stop = handler(req, resp)
+	assert.Same(t, result, resp)
+	assert.False(t, stop)
+	table = result.Options.Get(dhcpv4.OptionStaticRoutingTable)
+	routes = dhcpv4.Routes{}
+	if err = routes.FromBytes(table); err != nil {
+		t.Errorf("FromBytes(%v) Unexpected error state: %v", table, err)
+	}
 	if assert.NoError(t, err) {
 		if assert.Equal(t, 2, len(routes)) {
 			assert.Equal(t, "10.0.0.0/8", routes[0].Dest.String())


### PR DESCRIPTION
Now each plugin instance now has its own state

If we use coreDHCP as a library and run multiple servers, we can't separate configs variables for each server. This PR fix this problem.

Signed-off-by: Dmitrii Aleksandrov <goodmobiledevices@gmail.com>