### PR TITLE
plugins/range: added hostname field to database

### DIFF
--- a/plugins/range/storage_test.go
+++ b/plugins/range/storage_test.go
@@ -20,12 +20,12 @@ func testDBSetup() (*sql.DB, error) {
 		return nil, err
 	}
 	for _, record := range records {
-		stmt, err := db.Prepare("insert into leases4(mac, ip, expiry) values (?, ?, ?)")
+		stmt, err := db.Prepare("insert into leases4(mac, ip, expiry, hostname) values (?, ?, ?, ?)")
 		if err != nil {
 			return nil, fmt.Errorf("failed to prepare insert statement: %w", err)
 		}
 		defer stmt.Close()
-		if _, err := stmt.Exec(record.mac, record.ip.IP.String(), record.ip.expires); err != nil {
+		if _, err := stmt.Exec(record.mac, record.ip.IP.String(), record.ip.expires, record.ip.hostname); err != nil {
 			return nil, fmt.Errorf("failed to insert record into test db: %w", err)
 		}
 	}
@@ -37,12 +37,12 @@ var records = []struct {
 	mac string
 	ip  *Record
 }{
-	{"02:00:00:00:00:00", &Record{net.IPv4(10, 0, 0, 0), expire}},
-	{"02:00:00:00:00:01", &Record{net.IPv4(10, 0, 0, 1), expire}},
-	{"02:00:00:00:00:02", &Record{net.IPv4(10, 0, 0, 2), expire}},
-	{"02:00:00:00:00:03", &Record{net.IPv4(10, 0, 0, 3), expire}},
-	{"02:00:00:00:00:04", &Record{net.IPv4(10, 0, 0, 4), expire}},
-	{"02:00:00:00:00:05", &Record{net.IPv4(10, 0, 0, 5), expire}},
+	{"02:00:00:00:00:00", &Record{IP: net.IPv4(10, 0, 0, 0), expires: expire, hostname: "zero"}},
+	{"02:00:00:00:00:01", &Record{IP: net.IPv4(10, 0, 0, 1), expires: expire, hostname: "one"}},
+	{"02:00:00:00:00:02", &Record{IP: net.IPv4(10, 0, 0, 2), expires: expire, hostname: "two"}},
+	{"02:00:00:00:00:03", &Record{IP: net.IPv4(10, 0, 0, 3), expires: expire, hostname: "three"}},
+	{"02:00:00:00:00:04", &Record{IP: net.IPv4(10, 0, 0, 4), expires: expire, hostname: "four"}},
+	{"02:00:00:00:00:05", &Record{IP: net.IPv4(10, 0, 0, 5), expires: expire, hostname: "five"}},
 }
 
 func TestLoadRecords(t *testing.T) {
@@ -59,13 +59,13 @@ func TestLoadRecords(t *testing.T) {
 	mapRec := make(map[string]*Record)
 	for _, rec := range records {
 		var (
-			ip, mac string
-			expiry  int
+			ip, mac, hostname string
+			expiry            int
 		)
-		if err := db.QueryRow("select mac, ip, expiry from leases4 where mac = ?", rec.mac).Scan(&mac, &ip, &expiry); err != nil {
+		if err := db.QueryRow("select mac, ip, expiry, hostname from leases4 where mac = ?", rec.mac).Scan(&mac, &ip, &expiry, &hostname); err != nil {
 			t.Fatalf("record not found for mac=%s: %v", rec.mac, err)
 		}
-		mapRec[mac] = &Record{IP: net.ParseIP(ip), expires: expiry}
+		mapRec[mac] = &Record{IP: net.ParseIP(ip), expires: expiry, hostname: hostname}
 	}
 
 	assert.Equal(t, mapRec, parsedRec, "Loaded records differ from what's in the DB")
@@ -87,7 +87,7 @@ func TestWriteRecords(t *testing.T) {
 		if err := pl.saveIPAddress(hwaddr, rec.ip); err != nil {
 			t.Errorf("Failed to save ip for %s: %v", hwaddr, err)
 		}
-		mapRec[hwaddr.String()] = &Record{IP: rec.ip.IP, expires: rec.ip.expires}
+		mapRec[hwaddr.String()] = &Record{IP: rec.ip.IP, expires: rec.ip.expires, hostname: rec.ip.hostname}
 	}
 
 	parsedRec, err := loadRecords(pl.leasedb)


### PR DESCRIPTION
Added the `hostname` field in the sqlite database to simplify debugging.

 Example output:
```
$ echo 'select * from leases4;' | sudo sqlite3 leases4.db
98:e8:fa:XX:XX:XX|192.168.1.130|1705666178|nas
...
```