### PR TITLE
plugins/range: fixed memory leak in sqlite3 usage

### DIFF
--- a/plugins/range/storage.go
+++ b/plugins/range/storage.go
@@ -35,8 +35,8 @@ func loadRecords(db *sql.DB) (map[string]*Record, error) {
 	defer rows.Close()
 	var (
 		mac, ip, hostname string
-		expiry  int
-		records = make(map[string]*Record)
+		expiry            int
+		records           = make(map[string]*Record)
 	)
 	for rows.Next() {
 		if err := rows.Scan(&mac, &ip, &expiry, &hostname); err != nil {
@@ -64,6 +64,7 @@ func (p *PluginState) saveIPAddress(mac net.HardwareAddr, record *Record) error 
 	if err != nil {
 		return fmt.Errorf("statement preparation failed: %w", err)
 	}
+	defer stmt.Close()
 	if _, err := stmt.Exec(
 		mac.String(),
 		record.IP.String(),


### PR DESCRIPTION
I introduced a memory leak in the previous commit in the `range` plugin, by not closing a sqlite3 statement in a hot code path. This commit fixes it.

The graph below shows the effect of the fix on memory usage. The first annotation is a manual restart when the memory pressure was too high. The second restart marks the application of the patch. The correct behaviour is shown after the second restart, where the RSS usage flatlines after restarting.

<img width="720" alt="Screenshot 2024-02-20 at 20 57 06" src="https://github.com/coredhcp/coredhcp/assets/2356960/0b688bd7-2d48-4fbd-bdea-70392b1e0825">
 