### PR TITLE
Add README note to the debugging client

### DIFF
--- a/cmds/client/README.md
+++ b/cmds/client/README.md
@@ -1,0 +1,5 @@
+# DHCPv6 debug client
+
+This is a simple dhcpv6 client for use as a debugging tool with coredhcp
+
+***This is not a general-purpose DHCP client. This is only a testing/debugging tool for developing CoreDHCP***


### PR DESCRIPTION
There's been a few issues opened by people trying to use `cmds/client` as a general-purpose dhcp client and for DHCPv4. Add a README to hopefully make it clear that this is not part of CoreDHCP but an internal debugging tool