### PR TITLE
server: Ignore net.ErrClosed errors when shutting down

### DIFF
--- a/cmds/coredhcp-generator/coredhcp.go.template
+++ b/cmds/coredhcp-generator/coredhcp.go.template
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"time"
 
 	"github.com/coredhcp/coredhcp/config"
 	"github.com/coredhcp/coredhcp/logger"
@@ -100,7 +99,6 @@ func main() {
 		log.Fatal(err)
 	}
 	if err := srv.Wait(); err != nil {
-		log.Print(err)
+		log.Error(err)
 	}
-	time.Sleep(time.Second)
 }

--- a/cmds/coredhcp/main.go
+++ b/cmds/coredhcp/main.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"time"
 
 	"github.com/coredhcp/coredhcp/config"
 	"github.com/coredhcp/coredhcp/logger"
@@ -122,7 +121,6 @@ func main() {
 		log.Fatal(err)
 	}
 	if err := srv.Wait(); err != nil {
-		log.Print(err)
+		log.Error(err)
 	}
-	time.Sleep(time.Second)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/coredhcp/coredhcp
 
-go 1.19
+go 1.20
 
 require (
 	github.com/bits-and-blooms/bitset v1.13.0

--- a/server/handle.go
+++ b/server/handle.go
@@ -5,6 +5,7 @@
 package server
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"sync"
@@ -209,7 +210,10 @@ func (l *listener6) Serve() error {
 		b = b[:MaxDatagram] //Reslice to max capacity in case the buffer in pool was resliced smaller
 
 		n, oob, peer, err := l.ReadFrom(b)
-		if err != nil {
+		if errors.Is(err, net.ErrClosed) {
+			// Server is quitting
+			return nil
+		} else if err != nil {
 			log.Printf("Error reading from connection: %v", err)
 			return err
 		}
@@ -225,7 +229,10 @@ func (l *listener4) Serve() error {
 		b = b[:MaxDatagram] //Reslice to max capacity in case the buffer in pool was resliced smaller
 
 		n, oob, peer, err := l.ReadFrom(b)
-		if err != nil {
+		if errors.Is(err, net.ErrClosed) {
+			// Server is quitting
+			return nil
+		} else if err != nil {
 			log.Printf("Error reading from connection: %v", err)
 			return err
 		}


### PR DESCRIPTION
Fixes #103

Also make `server.Wait` wait for all the listeners to exit, instead of returning when the first one closes, which we couldn't do before because of the spurious errors it would return - this ensures that the server is completely shut down when `server.Wait` returns, instead of potentially still having listeners answering their last requests.

`errors.Join` requires go 1.20, update go.mod accordingly. CI already runs on 1.20 and up only so doesn't need changes