### PR TITLE
Remove use of deprecated rand.Read

### DIFF
--- a/plugins/allocators/ipcalc_test.go
+++ b/plugins/allocators/ipcalc_test.go
@@ -57,8 +57,10 @@ func ExampleAddPrefixes() {
 
 // Offset is used as a hash function, so it needs to be reasonably fast
 func BenchmarkOffset(b *testing.B) {
+	// Need predictable randomness for benchmark reproducibility
+	rng := rand.New(rand.NewSource(0))
 	addresses := make([]byte, b.N*net.IPv6len*2)
-	_, err := rand.Read(addresses)
+	_, err := rng.Read(addresses)
 	if err != nil {
 		b.Fatalf("Could not generate random addresses: %v", err)
 	}


### PR DESCRIPTION
Using the global non-cryptographic rand source is deprecated since go 1.20, so instead we make an explicit local one with a fixed seed for benchmarking

This was failing in CI: https://github.com/coredhcp/coredhcp/actions/runs/9852814374/job/27202061778