### PR TITLE
feat(plugins/range): add support for a single IP address

### DIFF
--- a/plugins/range/plugin.go
+++ b/plugins/range/plugin.go
@@ -111,8 +111,8 @@ func setupRange(args ...string) (handler.Handler4, error) {
 	if ipRangeEnd.To4() == nil {
 		return nil, fmt.Errorf("invalid IPv4 address: %v", args[2])
 	}
-	if binary.BigEndian.Uint32(ipRangeStart.To4()) >= binary.BigEndian.Uint32(ipRangeEnd.To4()) {
-		return nil, errors.New("start of IP range has to be lower than the end of an IP range")
+	if binary.BigEndian.Uint32(ipRangeStart.To4()) > binary.BigEndian.Uint32(ipRangeEnd.To4()) {
+		return nil, errors.New("start of IP range has to be lower than or equal to the end of an IP range")
 	}
 
 	p.allocator, err = bitmap.NewIPv4Allocator(ipRangeStart, ipRangeEnd)


### PR DESCRIPTION
This is mainly done for usage in a test context, where it would be nice to ensure that only a single IP address can be used.