### PR TITLE
plugins/file: Watch parent directory in autorefresh to catch file renames

### DIFF
--- a/cmds/coredhcp/config.yml.example
+++ b/cmds/coredhcp/config.yml.example
@@ -77,6 +77,9 @@ server6:
         # The file format is one lease per line, "<hw address> <IPv6>"
         # When the 'autorefresh' argument is given, the plugin will try to refresh
         # the lease mapping during runtime whenever the lease file is updated.
+        # Caution! autorefresh is best effort. There are many file manipulations
+        # that will not be detected and race conditions that can lead to incorrect
+        # behavior (reading partial file updates)
         - file: "leases.txt"
 
         # dns adds information about available DNS resolvers to the responses

--- a/plugins/file/plugin.go
+++ b/plugins/file/plugin.go
@@ -52,6 +52,7 @@ import (
 	"net"
 	"net/netip"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -262,14 +263,22 @@ func setupFile(v6 bool, args ...string) (handler.Handler6, handler.Handler4, err
 		}
 
 		// have file watcher watch over lease file
-		if err = watcher.Add(filename); err != nil {
+		if err = watcher.Add(filepath.Dir(filename)); err != nil {
 			return nil, nil, fmt.Errorf("failed to watch %s: %w", filename, err)
 		}
 
 		// very simple watcher on the lease file to trigger a refresh on any event
 		// on the file
 		go func() {
-			for range watcher.Events {
+			for evt := range watcher.Events {
+				if evt.Name != filename {
+					continue
+				}
+				if evt.Has(fsnotify.Remove) {
+					log.Warningf("lease file %s went away, not reloading", filename)
+					continue
+				}
+
 				err := loadFromFile(v6, filename)
 				if err != nil {
 					log.Warningf("failed to refresh from %s: %s", filename, err)


### PR DESCRIPTION
Partial fix for #240 to explicitly support atomic updates through the "write to temp file in the same directory then rename over the original file" scheme. This uses the scheme documented by upstream fsnotify of watching the parent directory and filtering on the file being affected, instead of watching the file itself

This is still inherently best-effort and there are various options that are not tested and probably don't work (f.ex network file systems, single-file mounts in containers, replacing the directory entirely)

Fixes: #240